### PR TITLE
Fix 'literalinclude' warnings

### DIFF
--- a/docs/source/developer/unit_testing.rst
+++ b/docs/source/developer/unit_testing.rst
@@ -34,7 +34,6 @@ function with the signature ``my_function(desc bool)``. This would look like:
 
 .. literalinclude:: /../../tests/docs/source/developer/unit_testing.cmake
    :lines: 3-8
-   :dedent:
 
 The basic pattern is that your function's first line should call
 ``cpp_assert_signature`` with the arguments provided to your function (this is
@@ -44,7 +43,6 @@ should use your function's actual types). To make sure you are calling
 
 .. literalinclude:: /../../tests/docs/source/developer/unit_testing.cmake
    :lines: 1-2, 10-35
-   :dedent:
 
 This is boilerplate heavy, but it is also the minimum required to
 make sure that you have correctly set the types of each argument and that your

--- a/docs/source/features/classes.rst
+++ b/docs/source/features/classes.rst
@@ -235,7 +235,7 @@ Member function definitions are structured in the following way:
 
 .. literalinclude:: /../../tests/docs/source/features/classes/define_member_function.cmake
    :lines: 6-21
-   :dedent: 1
+   :dedent: 4
 
 The structure of the above function definition contains the following pieces:
 
@@ -298,7 +298,6 @@ can be done in the following way:
 
 .. literalinclude:: /../../tests/docs/source/features/classes/function_overloading.cmake
    :lines: 3-17
-   :dedent: 1
 
 .. _features-classes-function-overload-resolution:
 
@@ -314,7 +313,7 @@ the above implementations in the following way:
 
 .. literalinclude:: /../../tests/docs/source/features/classes/function_overloading.cmake
    :lines: 22-29, 32-35
-   :dedent: 1
+   :dedent: 4
 
 .. note::
 
@@ -360,7 +359,6 @@ inherit from. We will use the following parent class:
 
 .. literalinclude:: /../../tests/docs/source/features/classes/derived_class.cmake
    :lines: 3-21
-   :dedent: 1
 
 To create a class called ``ChildClass`` that derives from ``ParentClass`` we
 just need to pass ``ParentClass`` as a parameter into the ``cpp_class``
@@ -368,7 +366,6 @@ statement we use to declare ``ChildClass``. This looks like:
 
 .. literalinclude:: /../../tests/docs/source/features/classes/derived_class.cmake
    :lines: 23-27
-   :dedent: 1
 
 We can define ``ChildClass`` that:
 
@@ -383,7 +380,6 @@ This can be done with the following:
 
 .. literalinclude:: /../../tests/docs/source/features/classes/derived_class.cmake
    :lines: 29-49
-   :dedent: 1
 
 .. _features-classes-using-derived-class:
 
@@ -394,21 +390,21 @@ We can create an instance of our derived class using the following:
 
 .. literalinclude:: /../../tests/docs/source/features/classes/derived_class.cmake
    :lines: 54-55
-   :dedent: 1
+   :dedent: 4
 
 The **inherited** attributes and functions of the parent class can be accessed
 through the derived class as well as the parent class:
 
 .. literalinclude:: /../../tests/docs/source/features/classes/derived_class.cmake
    :lines: 57-63
-   :dedent: 1
+   :dedent: 4
 
 The **overidden** attributes and functions in the derived class can be through
 the derived class as well as well as the parent class:
 
 .. literalinclude:: /../../tests/docs/source/features/classes/derived_class.cmake
    :lines: 65-71
-   :dedent: 1
+   :dedent: 4
 
 The **newly declared** attributes and functions in the derived class that are
 not present in the parent class can be accessed through the derived class as
@@ -416,7 +412,7 @@ well as the parent class:
 
 .. literalinclude:: /../../tests/docs/source/features/classes/derived_class.cmake
    :lines: 73-81
-   :dedent: 1
+   :dedent: 4
 
 .. _features-classes-multiple-class-inheritance:
 
@@ -458,26 +454,24 @@ virtual member function ``my_virtual_fxn`` with the following:
 
 .. literalinclude:: /../../tests/docs/source/features/classes/pure_virtual_member_functions.cmake
    :lines: 3-9
-   :dedent: 1
 
 Now we can create a class that derives from ``ParentClass`` and overrides
 ``my_virtual_fxn`` called ``ChildClass``:
 
 .. literalinclude:: /../../tests/docs/source/features/classes/pure_virtual_member_functions.cmake
    :lines: 11-19
-   :dedent: 1
 
 The overridden implementation can be called with an instance of ``ChildClass``:
 
 .. literalinclude:: /../../tests/docs/source/features/classes/pure_virtual_member_functions.cmake
    :lines: 24-27
-   :dedent: 1
+   :dedent: 4
 
 or using ``ParentClass`` with a ``ChildClass`` instance:
 
 .. literalinclude:: /../../tests/docs/source/features/classes/pure_virtual_member_functions.cmake
    :lines: 31-33
-   :dedent: 1
+   :dedent: 4
 
 .. warning::
 

--- a/docs/source/features/classes.rst
+++ b/docs/source/features/classes.rst
@@ -235,7 +235,7 @@ Member function definitions are structured in the following way:
 
 .. literalinclude:: /../../tests/docs/source/features/classes/define_member_function.cmake
    :lines: 6-21
-   :dedent:
+   :dedent: 1
 
 The structure of the above function definition contains the following pieces:
 
@@ -298,7 +298,7 @@ can be done in the following way:
 
 .. literalinclude:: /../../tests/docs/source/features/classes/function_overloading.cmake
    :lines: 3-17
-   :dedent:
+   :dedent: 1
 
 .. _features-classes-function-overload-resolution:
 
@@ -314,7 +314,7 @@ the above implementations in the following way:
 
 .. literalinclude:: /../../tests/docs/source/features/classes/function_overloading.cmake
    :lines: 22-29, 32-35
-   :dedent:
+   :dedent: 1
 
 .. note::
 
@@ -360,7 +360,7 @@ inherit from. We will use the following parent class:
 
 .. literalinclude:: /../../tests/docs/source/features/classes/derived_class.cmake
    :lines: 3-21
-   :dedent:
+   :dedent: 1
 
 To create a class called ``ChildClass`` that derives from ``ParentClass`` we
 just need to pass ``ParentClass`` as a parameter into the ``cpp_class``
@@ -368,7 +368,7 @@ statement we use to declare ``ChildClass``. This looks like:
 
 .. literalinclude:: /../../tests/docs/source/features/classes/derived_class.cmake
    :lines: 23-27
-   :dedent:
+   :dedent: 1
 
 We can define ``ChildClass`` that:
 
@@ -383,7 +383,7 @@ This can be done with the following:
 
 .. literalinclude:: /../../tests/docs/source/features/classes/derived_class.cmake
    :lines: 29-49
-   :dedent:
+   :dedent: 1
 
 .. _features-classes-using-derived-class:
 
@@ -394,21 +394,21 @@ We can create an instance of our derived class using the following:
 
 .. literalinclude:: /../../tests/docs/source/features/classes/derived_class.cmake
    :lines: 54-55
-   :dedent:
+   :dedent: 1
 
 The **inherited** attributes and functions of the parent class can be accessed
 through the derived class as well as the parent class:
 
 .. literalinclude:: /../../tests/docs/source/features/classes/derived_class.cmake
    :lines: 57-63
-   :dedent:
+   :dedent: 1
 
 The **overidden** attributes and functions in the derived class can be through
 the derived class as well as well as the parent class:
 
 .. literalinclude:: /../../tests/docs/source/features/classes/derived_class.cmake
    :lines: 65-71
-   :dedent:
+   :dedent: 1
 
 The **newly declared** attributes and functions in the derived class that are
 not present in the parent class can be accessed through the derived class as
@@ -416,7 +416,7 @@ well as the parent class:
 
 .. literalinclude:: /../../tests/docs/source/features/classes/derived_class.cmake
    :lines: 73-81
-   :dedent:
+   :dedent: 1
 
 .. _features-classes-multiple-class-inheritance:
 
@@ -458,26 +458,26 @@ virtual member function ``my_virtual_fxn`` with the following:
 
 .. literalinclude:: /../../tests/docs/source/features/classes/pure_virtual_member_functions.cmake
    :lines: 3-9
-   :dedent:
+   :dedent: 1
 
 Now we can create a class that derives from ``ParentClass`` and overrides
 ``my_virtual_fxn`` called ``ChildClass``:
 
 .. literalinclude:: /../../tests/docs/source/features/classes/pure_virtual_member_functions.cmake
    :lines: 11-19
-   :dedent:
+   :dedent: 1
 
 The overridden implementation can be called with an instance of ``ChildClass``:
 
 .. literalinclude:: /../../tests/docs/source/features/classes/pure_virtual_member_functions.cmake
    :lines: 24-27
-   :dedent:
+   :dedent: 1
 
 or using ``ParentClass`` with a ``ChildClass`` instance:
 
 .. literalinclude:: /../../tests/docs/source/features/classes/pure_virtual_member_functions.cmake
    :lines: 31-33
-   :dedent:
+   :dedent: 1
 
 .. warning::
 

--- a/docs/source/features/exceptions.rst
+++ b/docs/source/features/exceptions.rst
@@ -16,7 +16,7 @@ this:
 
 .. literalinclude:: /../../tests/docs/source/features/exceptions/basic_try_catch.cmake
    :lines: 6-17
-   :dedent:
+   :dedent: 1
 
 Handling Multiple Types of Exceptions
 =====================================
@@ -25,7 +25,7 @@ Multiple exception handlers for different types of exceptions can be declared:
 
 .. literalinclude:: /../../tests/docs/source/features/exceptions/handle_multiple_exception_types.cmake
    :lines: 6-20, 24-26
-   :dedent:
+   :dedent: 1
 
 Nested Try-Catch Blocks
 =======================
@@ -36,7 +36,7 @@ block will be called:
 
 .. literalinclude:: /../../tests/docs/source/features/exceptions/nested_try_catch.cmake
    :lines: 6-26, 29-31
-   :dedent:
+   :dedent: 1
 
 Adding Exception Handler for All Exceptions
 ===========================================
@@ -47,4 +47,4 @@ specific handler declared for their exception type can be declared by using the
 
 .. literalinclude:: /../../tests/docs/source/features/exceptions/handle_all_exceptions.cmake
    :lines: 6-15, 18-19
-   :dedent:
+   :dedent: 1

--- a/docs/source/features/exceptions.rst
+++ b/docs/source/features/exceptions.rst
@@ -16,7 +16,7 @@ this:
 
 .. literalinclude:: /../../tests/docs/source/features/exceptions/basic_try_catch.cmake
    :lines: 6-17
-   :dedent: 1
+   :dedent: 4
 
 Handling Multiple Types of Exceptions
 =====================================
@@ -25,7 +25,7 @@ Multiple exception handlers for different types of exceptions can be declared:
 
 .. literalinclude:: /../../tests/docs/source/features/exceptions/handle_multiple_exception_types.cmake
    :lines: 6-20, 24-26
-   :dedent: 1
+   :dedent: 4
 
 Nested Try-Catch Blocks
 =======================
@@ -36,7 +36,7 @@ block will be called:
 
 .. literalinclude:: /../../tests/docs/source/features/exceptions/nested_try_catch.cmake
    :lines: 6-26, 29-31
-   :dedent: 1
+   :dedent: 4
 
 Adding Exception Handler for All Exceptions
 ===========================================
@@ -47,4 +47,4 @@ specific handler declared for their exception type can be declared by using the
 
 .. literalinclude:: /../../tests/docs/source/features/exceptions/handle_all_exceptions.cmake
    :lines: 6-15, 18-19
-   :dedent: 1
+   :dedent: 4

--- a/docs/source/features/maps.rst
+++ b/docs/source/features/maps.rst
@@ -15,7 +15,7 @@ The map constructor is used to create an empty map:
 
 .. literalinclude:: /../../tests/docs/source/features/maps.cmake
    :lines: 11-12
-   :dedent:
+   :dedent: 1
 
 Optionally, key-value pairs can be provided to the map constructor. You must
 simply add keys and their corresponding values as arguments passed to the
@@ -23,7 +23,7 @@ constructor:
 
 .. literalinclude:: /../../tests/docs/source/features/maps.cmake
    :lines: 14-15
-   :dedent:
+   :dedent: 1
 
 Setting Values
 ==============
@@ -32,7 +32,7 @@ Values can be set by using the ``SET`` keyword:
 
 .. literalinclude:: /../../tests/docs/source/features/maps.cmake
    :lines: 17-18
-   :dedent:
+   :dedent: 1
 
 Accessing Values
 ================
@@ -41,7 +41,7 @@ Values can be accessed using ``GET`` keyword:
 
 .. literalinclude:: /../../tests/docs/source/features/maps.cmake
    :lines: 20-21
-   :dedent:
+   :dedent: 1
 
 Appending Values
 ================
@@ -50,7 +50,7 @@ Values can be appended by using the ``APPEND`` keyword:
 
 .. literalinclude:: /../../tests/docs/source/features/maps.cmake
    :lines: 25-26
-   :dedent:
+   :dedent: 1
 
 Copying a Map
 =============
@@ -59,7 +59,7 @@ Maps can be copied using the ``COPY`` keyword:
 
 .. literalinclude:: /../../tests/docs/source/features/maps.cmake
    :lines: 34-35
-   :dedent:
+   :dedent: 1
 
 Checking Equality of Maps
 =========================
@@ -68,7 +68,7 @@ Map equality can be checked using the ``EQUAL`` keyword:
 
 .. literalinclude:: /../../tests/docs/source/features/maps.cmake
    :lines: 37-38
-   :dedent:
+   :dedent: 1
 
 Checking if a Map has a Key
 ===========================
@@ -77,7 +77,7 @@ Check whether the map contains a key with the ``HAS_KEY`` keyword:
 
 .. literalinclude:: /../../tests/docs/source/features/maps.cmake
    :lines: 42-43
-   :dedent:
+   :dedent: 1
 
 Getting a Map's Keys
 ====================
@@ -86,4 +86,4 @@ A list of a map's keys can be retrieved using the ``KEYS`` keyword:
 
 .. literalinclude:: /../../tests/docs/source/features/maps.cmake
    :lines: 47-48
-   :dedent:
+   :dedent: 1

--- a/docs/source/features/maps.rst
+++ b/docs/source/features/maps.rst
@@ -15,7 +15,7 @@ The map constructor is used to create an empty map:
 
 .. literalinclude:: /../../tests/docs/source/features/maps.cmake
    :lines: 11-12
-   :dedent: 1
+   :dedent: 4
 
 Optionally, key-value pairs can be provided to the map constructor. You must
 simply add keys and their corresponding values as arguments passed to the
@@ -23,7 +23,7 @@ constructor:
 
 .. literalinclude:: /../../tests/docs/source/features/maps.cmake
    :lines: 14-15
-   :dedent: 1
+   :dedent: 4
 
 Setting Values
 ==============
@@ -32,7 +32,7 @@ Values can be set by using the ``SET`` keyword:
 
 .. literalinclude:: /../../tests/docs/source/features/maps.cmake
    :lines: 17-18
-   :dedent: 1
+   :dedent: 4
 
 Accessing Values
 ================
@@ -41,7 +41,7 @@ Values can be accessed using ``GET`` keyword:
 
 .. literalinclude:: /../../tests/docs/source/features/maps.cmake
    :lines: 20-21
-   :dedent: 1
+   :dedent: 4
 
 Appending Values
 ================
@@ -50,7 +50,7 @@ Values can be appended by using the ``APPEND`` keyword:
 
 .. literalinclude:: /../../tests/docs/source/features/maps.cmake
    :lines: 25-26
-   :dedent: 1
+   :dedent: 4
 
 Copying a Map
 =============
@@ -59,7 +59,7 @@ Maps can be copied using the ``COPY`` keyword:
 
 .. literalinclude:: /../../tests/docs/source/features/maps.cmake
    :lines: 34-35
-   :dedent: 1
+   :dedent: 4
 
 Checking Equality of Maps
 =========================
@@ -68,7 +68,7 @@ Map equality can be checked using the ``EQUAL`` keyword:
 
 .. literalinclude:: /../../tests/docs/source/features/maps.cmake
    :lines: 37-38
-   :dedent: 1
+   :dedent: 4
 
 Checking if a Map has a Key
 ===========================
@@ -77,7 +77,7 @@ Check whether the map contains a key with the ``HAS_KEY`` keyword:
 
 .. literalinclude:: /../../tests/docs/source/features/maps.cmake
    :lines: 42-43
-   :dedent: 1
+   :dedent: 4
 
 Getting a Map's Keys
 ====================
@@ -86,4 +86,4 @@ A list of a map's keys can be retrieved using the ``KEYS`` keyword:
 
 .. literalinclude:: /../../tests/docs/source/features/maps.cmake
    :lines: 47-48
-   :dedent: 1
+   :dedent: 4

--- a/docs/source/features/serialization.rst
+++ b/docs/source/features/serialization.rst
@@ -26,7 +26,7 @@ For example, if we want to serialize a map called ``my_map``, we could do:
 
 .. literalinclude:: /../../tests/docs/source/features/serialization.cmake
    :lines: 8-14
-   :dedent: 1
+   :dedent: 8
 
 Serialization of Lists
 ======================
@@ -37,7 +37,7 @@ For example, a list can be serialized as follows:
 
 .. literalinclude:: /../../tests/docs/source/features/serialization.cmake
    :lines: 24-30
-   :dedent: 1
+   :dedent: 8
 
 Serialization of other Native CMake Types
 =========================================
@@ -97,7 +97,7 @@ Take the following class for example:
 
 .. literalinclude:: /../../tests/docs/source/features/serialization.cmake
    :lines: 40-60
-   :dedent: 1
+   :dedent: 8
 
 An instance of the ``Automobile`` class serializes into the following JSON
 object:

--- a/docs/source/features/serialization.rst
+++ b/docs/source/features/serialization.rst
@@ -26,7 +26,7 @@ For example, if we want to serialize a map called ``my_map``, we could do:
 
 .. literalinclude:: /../../tests/docs/source/features/serialization.cmake
    :lines: 8-14
-   :dedent:
+   :dedent: 1
 
 Serialization of Lists
 ======================
@@ -37,7 +37,7 @@ For example, a list can be serialized as follows:
 
 .. literalinclude:: /../../tests/docs/source/features/serialization.cmake
    :lines: 24-30
-   :dedent:
+   :dedent: 1
 
 Serialization of other Native CMake Types
 =========================================
@@ -97,7 +97,7 @@ Take the following class for example:
 
 .. literalinclude:: /../../tests/docs/source/features/serialization.cmake
    :lines: 40-60
-   :dedent:
+   :dedent: 1
 
 An instance of the ``Automobile`` class serializes into the following JSON
 object:

--- a/docs/source/getting_started/cmakepp_examples/classes.rst
+++ b/docs/source/getting_started/cmakepp_examples/classes.rst
@@ -23,13 +23,13 @@ color attribute, and print out that value:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/classes/writing_basic_class.cmake
    :lines: 15-24
-   :dedent: 1
+   :dedent: 4
 
 We can also set the value of the attribute:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/classes/writing_basic_class.cmake
-   :lines: 28-37
-   :dedent: 1
+   :lines: 26-35
+   :dedent: 4
 
 See :ref:`features-classes` for more information about CMakePP classes.
 
@@ -50,7 +50,7 @@ did in the previous example) we can call our function using the following:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/classes/member_functions.cmake
    :lines: 21-27
-   :dedent: 1
+   :dedent: 4
 
 See :ref:`features-classes-member-functions` for more information about writing 
 class member functions.
@@ -66,14 +66,14 @@ adding the following to our class:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/classes/function_arguments.cmake
    :lines: 15-19
-   :dedent: 1
+   :dedent: 4
 
 Using our Automobile instance ``my_auto`` we can call the function in the
 following way:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/classes/function_arguments.cmake
    :lines: 30-33
-   :dedent: 1
+   :dedent: 4
 
 See :ref:`features-types` for a list and descriptions of data types 
 supported by the CMakePP language and :ref:`features-classes-member-functions` 
@@ -102,12 +102,13 @@ prepended to their name. Here is the function:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/classes/function_referencing_attributes.cmake
    :lines: 24-35
-   :dedent: 1
+   :dedent: 4
 
 This function can be accessed in the same way as previous examples:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/classes/function_referencing_attributes.cmake
    :lines: 46-49
+   :dedent: 4
 
 .. _examples-classes-return-value:
 
@@ -128,7 +129,7 @@ This is demonstrated by the following redefinition of ``describe_self``:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/classes/function_return_value.cmake
    :lines: 24-35
-   :dedent: 1
+   :dedent: 4
 
 .. note::
 
@@ -142,7 +143,7 @@ We can call this function and access its return value using the following:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/classes/function_return_value.cmake
    :lines: 46-52
-   :dedent: 1
+   :dedent: 4
 
 .. _examples-classes-multiple-return-points:
 
@@ -171,13 +172,13 @@ as follows:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/classes/function_multiple_return_points.cmake
    :lines: 24-49
-   :dedent: 1
+   :dedent: 4
 
 We can call the function in the following way:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/classes/function_multiple_return_points.cmake
    :lines: 60-65, 68-72
-   :dedent: 1
+   :dedent: 4
 
 .. _examples-classes-function-overloading:
 
@@ -192,7 +193,7 @@ definition:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/classes/function_overloading.cmake
    :lines: 18-22
-   :dedent: 1
+   :dedent: 4
 
 Now we can call the new function by passing in arguments with the correct types
 to match the signature of the new function we wrote. In this case we need to
@@ -200,7 +201,7 @@ pass in one integer to match the new signature:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/classes/function_overloading.cmake
    :lines: 66-70, 73-76
-   :dedent: 1
+   :dedent: 4
 
 .. _examples-classes-constructor-user-defined:
 
@@ -213,7 +214,7 @@ constructor that takes two integers to our ``Automobile`` class:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/classes/constructor_user_defined.cmake
    :lines: 12-15
-   :dedent: 1
+   :dedent: 4
 
 Multiple constructors can be added to a class. Calls to constructors will use
 function resolution in the same way the member function calls do. That is when a
@@ -240,7 +241,7 @@ automobile class has three attributes: ``color``, ``num_doors``, and
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/classes/constructor_kwargs.cmake
    :lines: 40
-   :dedent: 1
+   :dedent: 4
 
 This would set the value of ``color`` to ``red``, ``num_doors`` to ``4``, and
 ``owners`` to ``Alice;Bob;Chuck``.
@@ -264,7 +265,6 @@ precise description. We can define the class by writing the following:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/classes/derived_class.cmake
    :lines: 40-62
-   :dedent: 1
 
 We can now create an instance of our derived ``Car`` class and access its
 methods (and the methods inherited from its base class) through the ``Car``
@@ -272,14 +272,14 @@ class:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/classes/derived_class.cmake
    :lines: 69-77, 80-83
-   :dedent: 1
+   :dedent: 8
 
 Alternatively we can access the methods of the ``Car`` class through
 its base class ``Automobile``:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/classes/derived_class.cmake
    :lines: 94-98, 102-105
-   :dedent: 1
+   :dedent: 8
 
 .. _examples-classes-multiple-inheritance:
 
@@ -313,20 +313,20 @@ class:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/classes/multiple_inheritance_basics.cmake
    :lines: 43-44
-   :dedent: 1
+   :dedent: 8
 
 We can then access the attributes that are defined in each of the parent classes
 like we would any other attribute:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/classes/multiple_inheritance_basics.cmake
    :lines: 46-54
-   :dedent: 1
+   :dedent: 8
 
 We can access the functions defined in each of the parent classes as well:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/classes/multiple_inheritance_basics.cmake
    :lines: 65-66, 68, 70-73
-   :dedent: 1
+   :dedent: 8
 
 .. _examples-classes-multiple-inheritance-conflicting:
 
@@ -352,7 +352,7 @@ following:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/classes/multiple_inheritance_conflicting.cmake
    :lines: 36-41
-   :dedent: 1
+   :dedent: 8
 
 Now if we attempt to access the ``power_source`` attribute or call the 
 ``start`` function, the CMakePP language will search the parent classes in 
@@ -366,7 +366,7 @@ So, if we create an instance of ``ElectricTruck`` and attempt to access
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/classes/multiple_inheritance_conflicting.cmake
    :lines: 43-52, 55-58
-   :dedent: 1
+   :dedent: 8
 
 Alternatively, we could define our subclass with
 ``cpp_class(TruckElectric Truck ElectricVehicle)``. Note that we now placed
@@ -375,7 +375,7 @@ look in ``Truck`` first when searching for attributes and functions:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/classes/multiple_inheritance_conflicting.cmake
    :lines: 72-81, 84-87
-   :dedent: 1
+   :dedent: 8
 
 .. _examples-classes-pure-virtual-member-functions:
 
@@ -401,7 +401,7 @@ Now we can create an instance of the ``Truck`` class and call the
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/classes/pure_virtual_member_functions.cmake
    :lines: 25-30, 33-36
-   :dedent: 1
+   :dedent: 4
 
 .. warning::
 

--- a/docs/source/getting_started/cmakepp_examples/classes.rst
+++ b/docs/source/getting_started/cmakepp_examples/classes.rst
@@ -23,13 +23,13 @@ color attribute, and print out that value:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/classes/writing_basic_class.cmake
    :lines: 15-24
-   :dedent:
+   :dedent: 1
 
 We can also set the value of the attribute:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/classes/writing_basic_class.cmake
    :lines: 28-37
-   :dedent:
+   :dedent: 1
 
 See :ref:`features-classes` for more information about CMakePP classes.
 
@@ -50,7 +50,7 @@ did in the previous example) we can call our function using the following:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/classes/member_functions.cmake
    :lines: 21-27
-   :dedent:
+   :dedent: 1
 
 See :ref:`features-classes-member-functions` for more information about writing 
 class member functions.
@@ -66,14 +66,14 @@ adding the following to our class:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/classes/function_arguments.cmake
    :lines: 15-19
-   :dedent:
+   :dedent: 1
 
 Using our Automobile instance ``my_auto`` we can call the function in the
 following way:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/classes/function_arguments.cmake
    :lines: 30-33
-   :dedent:
+   :dedent: 1
 
 See :ref:`features-types` for a list and descriptions of data types 
 supported by the CMakePP language and :ref:`features-classes-member-functions` 
@@ -102,7 +102,7 @@ prepended to their name. Here is the function:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/classes/function_referencing_attributes.cmake
    :lines: 24-35
-   :dedent:
+   :dedent: 1
 
 This function can be accessed in the same way as previous examples:
 
@@ -128,7 +128,7 @@ This is demonstrated by the following redefinition of ``describe_self``:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/classes/function_return_value.cmake
    :lines: 24-35
-   :dedent:
+   :dedent: 1
 
 .. note::
 
@@ -142,7 +142,7 @@ We can call this function and access its return value using the following:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/classes/function_return_value.cmake
    :lines: 46-52
-   :dedent:
+   :dedent: 1
 
 .. _examples-classes-multiple-return-points:
 
@@ -171,13 +171,13 @@ as follows:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/classes/function_multiple_return_points.cmake
    :lines: 24-49
-   :dedent:
+   :dedent: 1
 
 We can call the function in the following way:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/classes/function_multiple_return_points.cmake
    :lines: 60-65, 68-72
-   :dedent:
+   :dedent: 1
 
 .. _examples-classes-function-overloading:
 
@@ -192,7 +192,7 @@ definition:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/classes/function_overloading.cmake
    :lines: 18-22
-   :dedent:
+   :dedent: 1
 
 Now we can call the new function by passing in arguments with the correct types
 to match the signature of the new function we wrote. In this case we need to
@@ -200,7 +200,7 @@ pass in one integer to match the new signature:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/classes/function_overloading.cmake
    :lines: 66-70, 73-76
-   :dedent:
+   :dedent: 1
 
 .. _examples-classes-constructor-user-defined:
 
@@ -213,7 +213,7 @@ constructor that takes two integers to our ``Automobile`` class:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/classes/constructor_user_defined.cmake
    :lines: 12-15
-   :dedent:
+   :dedent: 1
 
 Multiple constructors can be added to a class. Calls to constructors will use
 function resolution in the same way the member function calls do. That is when a
@@ -240,7 +240,7 @@ automobile class has three attributes: ``color``, ``num_doors``, and
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/classes/constructor_kwargs.cmake
    :lines: 40
-   :dedent:
+   :dedent: 1
 
 This would set the value of ``color`` to ``red``, ``num_doors`` to ``4``, and
 ``owners`` to ``Alice;Bob;Chuck``.
@@ -264,7 +264,7 @@ precise description. We can define the class by writing the following:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/classes/derived_class.cmake
    :lines: 40-62
-   :dedent:
+   :dedent: 1
 
 We can now create an instance of our derived ``Car`` class and access its
 methods (and the methods inherited from its base class) through the ``Car``
@@ -272,14 +272,14 @@ class:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/classes/derived_class.cmake
    :lines: 69-77, 80-83
-   :dedent:
+   :dedent: 1
 
 Alternatively we can access the methods of the ``Car`` class through
 its base class ``Automobile``:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/classes/derived_class.cmake
    :lines: 94-98, 102-105
-   :dedent:
+   :dedent: 1
 
 .. _examples-classes-multiple-inheritance:
 
@@ -313,20 +313,20 @@ class:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/classes/multiple_inheritance_basics.cmake
    :lines: 43-44
-   :dedent:
+   :dedent: 1
 
 We can then access the attributes that are defined in each of the parent classes
 like we would any other attribute:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/classes/multiple_inheritance_basics.cmake
    :lines: 46-54
-   :dedent:
+   :dedent: 1
 
 We can access the functions defined in each of the parent classes as well:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/classes/multiple_inheritance_basics.cmake
    :lines: 65-66, 68, 70-73
-   :dedent:
+   :dedent: 1
 
 .. _examples-classes-multiple-inheritance-conflicting:
 
@@ -352,7 +352,7 @@ following:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/classes/multiple_inheritance_conflicting.cmake
    :lines: 36-41
-   :dedent:
+   :dedent: 1
 
 Now if we attempt to access the ``power_source`` attribute or call the 
 ``start`` function, the CMakePP language will search the parent classes in 
@@ -366,7 +366,7 @@ So, if we create an instance of ``ElectricTruck`` and attempt to access
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/classes/multiple_inheritance_conflicting.cmake
    :lines: 43-52, 55-58
-   :dedent:
+   :dedent: 1
 
 Alternatively, we could define our subclass with
 ``cpp_class(TruckElectric Truck ElectricVehicle)``. Note that we now placed
@@ -375,7 +375,7 @@ look in ``Truck`` first when searching for attributes and functions:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/classes/multiple_inheritance_conflicting.cmake
    :lines: 72-81, 84-87
-   :dedent:
+   :dedent: 1
 
 .. _examples-classes-pure-virtual-member-functions:
 
@@ -401,7 +401,7 @@ Now we can create an instance of the ``Truck`` class and call the
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/classes/pure_virtual_member_functions.cmake
    :lines: 25-30, 33-36
-   :dedent:
+   :dedent: 1
 
 .. warning::
 

--- a/docs/source/getting_started/cmakepp_examples/utilities.rst
+++ b/docs/source/getting_started/cmakepp_examples/utilities.rst
@@ -17,7 +17,7 @@ variables, including objects and maps.
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/utilities/variable_equality.cmake
    :lines: 6-21
-   :dedent:
+   :dedent: 1
 
 .. note::
 
@@ -33,7 +33,7 @@ We can use ``cpp_serialize`` to serialize a variable into a JSON string:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/utilities/variable_serialization.cmake
    :lines: 6-18
-   :dedent:
+   :dedent: 1
 
 Copying a Variable
 ==================
@@ -43,7 +43,7 @@ regardless of what type it is:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/utilities/variable_copy.cmake
    :lines: 6-20
-   :dedent:
+   :dedent: 1
 
 Checking if Variable Contains a Value
 =====================================
@@ -60,7 +60,7 @@ We can use ``cpp_contains`` to check if a
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/utilities/variable_desc_contains_substring.cmake
    :lines: 6-22
-   :dedent:
+   :dedent: 1
 
 Check if a List Contains a Value
 --------------------------------
@@ -70,7 +70,7 @@ contains a value:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/utilities/variable_list_contains_value.cmake
    :lines: 6-22
-   :dedent:
+   :dedent: 1
 
 .. note::
 
@@ -84,7 +84,7 @@ contains a key:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/utilities/variable_map_contains_key.cmake
    :lines: 6-19
-   :dedent:
+   :dedent: 1
 
 Determining the Type of a Variable
 ==================================
@@ -94,7 +94,7 @@ variable or value:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/utilities/variable_type.cmake
    :lines: 6-10
-   :dedent:
+   :dedent: 1
 
 .. note::
 
@@ -107,7 +107,7 @@ We can use ``cpp_assert`` to assert that a given value is true:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/utilities/assert.cmake
    :lines: 8-11, 16-18
-   :dedent:
+   :dedent: 1
 
 If an assert fails, it will stop the execution of the program and print the
 provided assertion message along with the call stack from where the assertion
@@ -120,7 +120,7 @@ We can use ``cpp_file_exists`` to check if files exist:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/utilities/file_exists.cmake
    :lines: 6-20
-   :dedent:
+   :dedent: 1
 
 .. note::
    
@@ -134,7 +134,7 @@ get, set, and append global values:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/utilities/global_variables.cmake
    :lines: 6-14, 17-24
-   :dedent:
+   :dedent: 1
 
 Creating a Unique Identifier
 ============================
@@ -143,4 +143,4 @@ We can use ``cpp_unique_id`` to create a unique identifier:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/utilities/create_unique_id.cmake
    :lines: 6-10
-   :dedent:
+   :dedent: 1

--- a/docs/source/getting_started/cmakepp_examples/utilities.rst
+++ b/docs/source/getting_started/cmakepp_examples/utilities.rst
@@ -17,7 +17,7 @@ variables, including objects and maps.
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/utilities/variable_equality.cmake
    :lines: 6-21
-   :dedent: 1
+   :dedent: 4
 
 .. note::
 
@@ -33,7 +33,7 @@ We can use ``cpp_serialize`` to serialize a variable into a JSON string:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/utilities/variable_serialization.cmake
    :lines: 6-18
-   :dedent: 1
+   :dedent: 4
 
 Copying a Variable
 ==================
@@ -43,7 +43,7 @@ regardless of what type it is:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/utilities/variable_copy.cmake
    :lines: 6-20
-   :dedent: 1
+   :dedent: 4
 
 Checking if Variable Contains a Value
 =====================================
@@ -60,7 +60,7 @@ We can use ``cpp_contains`` to check if a
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/utilities/variable_desc_contains_substring.cmake
    :lines: 6-22
-   :dedent: 1
+   :dedent: 4
 
 Check if a List Contains a Value
 --------------------------------
@@ -70,7 +70,7 @@ contains a value:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/utilities/variable_list_contains_value.cmake
    :lines: 6-22
-   :dedent: 1
+   :dedent: 4
 
 .. note::
 
@@ -84,7 +84,7 @@ contains a key:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/utilities/variable_map_contains_key.cmake
    :lines: 6-19
-   :dedent: 1
+   :dedent: 4
 
 Determining the Type of a Variable
 ==================================
@@ -94,7 +94,7 @@ variable or value:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/utilities/variable_type.cmake
    :lines: 6-10
-   :dedent: 1
+   :dedent: 4
 
 .. note::
 
@@ -107,7 +107,7 @@ We can use ``cpp_assert`` to assert that a given value is true:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/utilities/assert.cmake
    :lines: 8-11, 16-18
-   :dedent: 1
+   :dedent: 8
 
 If an assert fails, it will stop the execution of the program and print the
 provided assertion message along with the call stack from where the assertion
@@ -120,7 +120,7 @@ We can use ``cpp_file_exists`` to check if files exist:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/utilities/file_exists.cmake
    :lines: 6-20
-   :dedent: 1
+   :dedent: 4
 
 .. note::
    
@@ -134,7 +134,7 @@ get, set, and append global values:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/utilities/global_variables.cmake
    :lines: 6-14, 17-24
-   :dedent: 1
+   :dedent: 4
 
 Creating a Unique Identifier
 ============================
@@ -143,4 +143,4 @@ We can use ``cpp_unique_id`` to create a unique identifier:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/utilities/create_unique_id.cmake
    :lines: 6-10
-   :dedent: 1
+   :dedent: 4


### PR DESCRIPTION
This is a brief attempt to try to fix some of the warnings in the documentation coming from `literalinclude` directives. I am not sure why they are all happening, so they might not all get fixed.