### PR TITLE
Protect escaped chars in object method arguments

### DIFF
--- a/cmake/cmakepp_lang/class/detail_/class.cmake.in
+++ b/cmake/cmakepp_lang/class/detail_/class.cmake.in
@@ -1,6 +1,7 @@
 include_guard()
 include(cmakepp_lang/object/object)
 include(cmakepp_lang/class/ctor)
+include(cmakepp_lang/utilities/encode_special_chars)
 
 #[[[ The template for the macro created for CMakePP classes.
 #
@@ -10,13 +11,16 @@ include(cmakepp_lang/class/ctor)
 #]]
 macro(@_cg_type@ _@_cg_type@_mode _@_cg_type@_this)
     cpp_assert_signature("${ARGV}" desc desc args)
+    message("---- @_cg_type@ ARGN: ${ARGN}") # DEBUG
+    cpp_encode_special_chars("${ARGN}" _@_cg_type@_encoded_args)
+    message("---- @_cg_type@ _@_cg_type@_encoded_args: ${_@_cg_type@_encoded_args}") # DEBUG
 
     cpp_sanitize_string(_@_cg_type@_nice_mode "${_@_cg_type@_mode}")
     if("${_@_cg_type@_nice_mode}" STREQUAL "ctor")
         # Handle CTOR call
-        cpp_class_ctor("${_@_cg_type@_this}" "@_cg_type@" ${ARGN})
+        cpp_class_ctor("${_@_cg_type@_this}" "@_cg_type@" ${_@_cg_type@_encoded_args})
     else()
         # Handle regular function call or set/get of attribute
-        _cpp_object("${_@_cg_type@_nice_mode}" "${_@_cg_type@_this}" ${ARGN})
+        _cpp_object("${_@_cg_type@_nice_mode}" "${_@_cg_type@_this}" ${_@_cg_type@_encoded_args})
     endif()
 endmacro()

--- a/cmake/cmakepp_lang/class/detail_/class.cmake.in
+++ b/cmake/cmakepp_lang/class/detail_/class.cmake.in
@@ -11,9 +11,7 @@ include(cmakepp_lang/utilities/encode_special_chars)
 #]]
 macro(@_cg_type@ _@_cg_type@_mode _@_cg_type@_this)
     cpp_assert_signature("${ARGV}" desc desc args)
-    message("---- @_cg_type@ ARGN: ${ARGN}") # DEBUG
     cpp_encode_special_chars("${ARGN}" _@_cg_type@_encoded_args)
-    message("---- @_cg_type@ _@_cg_type@_encoded_args: ${_@_cg_type@_encoded_args}") # DEBUG
 
     cpp_sanitize_string(_@_cg_type@_nice_mode "${_@_cg_type@_mode}")
     if("${_@_cg_type@_nice_mode}" STREQUAL "ctor")

--- a/cmake/cmakepp_lang/object/call.cmake
+++ b/cmake/cmakepp_lang/object/call.cmake
@@ -36,13 +36,11 @@ include(cmakepp_lang/utilities/sanitize_string)
 # member function capable of being called with the provided signature.
 #]]
 function(_cpp_object_call_guts _ocg_this _ocg_result _ocg_method)
-    message("---- _cpp_object_call_guts ARGN: ${ARGN}") # DEBUG
 
     # Make the signature (tuple with name of fxn and arg types) we want
     cpp_sanitize_string(_ocg_nice_method "${_ocg_method}")
     set(_ocg_sig "${_ocg_nice_method}")
     foreach(_ocg_arg_i "${_ocg_this}" ${ARGN})
-        message("---- _cpp_object_call_guts _ocg_arg_i: ${_ocg_arg_i}") # DEBUG
         cpp_type_of(_ocg_type_i "${_ocg_arg_i}")
         cpp_sanitize_string(_ocg_nice_type_i "${_ocg_type_i}")
         list(APPEND _ocg_sig "${_ocg_nice_type_i}")
@@ -99,7 +97,6 @@ endfunction()
 #]]
 macro(_cpp_object_call _oc_this _oc_method)
     cpp_assert_signature("${ARGV}" obj desc args)
-    # message("---- _cpp_object_call ARGN: ${ARGN}") # DEBUG
 
     _cpp_object_call_guts("${_oc_this}" __oc__symbol "${_oc_method}" ${ARGN})
     cpp_call_fxn("${__oc__symbol}" "${_oc_this}" ${ARGN})

--- a/cmake/cmakepp_lang/object/call.cmake
+++ b/cmake/cmakepp_lang/object/call.cmake
@@ -2,6 +2,7 @@ include_guard()
 include(cmakepp_lang/object/object)
 include(cmakepp_lang/types/type_of)
 include(cmakepp_lang/utilities/call_fxn)
+include(cmakepp_lang/utilities/encode_special_chars)
 include(cmakepp_lang/utilities/print_fxn_sig)
 include(cmakepp_lang/utilities/sanitize_string)
 
@@ -35,11 +36,13 @@ include(cmakepp_lang/utilities/sanitize_string)
 # member function capable of being called with the provided signature.
 #]]
 function(_cpp_object_call_guts _ocg_this _ocg_result _ocg_method)
+    message("---- _cpp_object_call_guts ARGN: ${ARGN}") # DEBUG
 
     # Make the signature (tuple with name of fxn and arg types) we want
     cpp_sanitize_string(_ocg_nice_method "${_ocg_method}")
     set(_ocg_sig "${_ocg_nice_method}")
     foreach(_ocg_arg_i "${_ocg_this}" ${ARGN})
+        message("---- _cpp_object_call_guts _ocg_arg_i: ${_ocg_arg_i}") # DEBUG
         cpp_type_of(_ocg_type_i "${_ocg_arg_i}")
         cpp_sanitize_string(_ocg_nice_type_i "${_ocg_type_i}")
         list(APPEND _ocg_sig "${_ocg_nice_type_i}")
@@ -96,6 +99,7 @@ endfunction()
 #]]
 macro(_cpp_object_call _oc_this _oc_method)
     cpp_assert_signature("${ARGV}" obj desc args)
+    # message("---- _cpp_object_call ARGN: ${ARGN}") # DEBUG
 
     _cpp_object_call_guts("${_oc_this}" __oc__symbol "${_oc_method}" ${ARGN})
     cpp_call_fxn("${__oc__symbol}" "${_oc_this}" ${ARGN})

--- a/cmake/cmakepp_lang/utilities/call_fxn.cmake
+++ b/cmake/cmakepp_lang/utilities/call_fxn.cmake
@@ -1,5 +1,6 @@
 include_guard()
 include(cmakepp_lang/utilities/unique_id)
+include(cmakepp_lang/utilities/decode_special_chars)
 
 #[[[ Performs most of the work for dynamically calling a function.
 #
@@ -15,19 +16,23 @@ include(cmakepp_lang/utilities/unique_id)
 # :param *args: The arguments to forward to the function.
 #]]
 function(_cpp_call_fxn_guts _cfg_fxn2call _cfg_result)
+    message("---- _cpp_call_fxn_guts ARGN: ${ARGN}") # DEBUG
     # Create a new arg list that is a copy of ARGN except all args are
     # surrounded with double quotes (to ensure strings with spaces aren't
     # parsed as lists)
     set(_cfg_args_list "")
     foreach(_cfg_current_arg ${ARGN}) # Loop over all args
+        # message("---- _cpp_call_fxn_guts _cfg_current_arg: ${_cfg_current_arg}") # DEBUG
         string(APPEND _cfg_args_list "\"${_cfg_current_arg}\" ")
     endforeach()
+
+    cpp_decode_special_chars("${_cfg_args_list}" _cfg_decoded_args)
 
     # Write a .cmake file that calls the function
     cpp_unique_id(_cfg_uuid)
     set(_cfg_file "${CMAKE_CURRENT_BINARY_DIR}/cmakepp/fxn_calls")
     set(_cfg_file "${_cfg_file}/${_cfg_fxn2call}_${_cfg_uuid}.cmake")
-    file(WRITE "${_cfg_file}" "${_cfg_fxn2call}(${_cfg_args_list})")
+    file(WRITE "${_cfg_file}" "${_cfg_fxn2call}(${_cfg_decoded_args})")
     set("${_cfg_result}" "${_cfg_file}" PARENT_SCOPE)
 endfunction()
 
@@ -49,6 +54,7 @@ endfunction()
 #    significantly complicate the implementation.
 #]]
 macro(cpp_call_fxn _cf_fxn2call)
+    # message("---- cpp_call_fxn ARGN: ${ARGN}") # DEBUG
     # Create a .cmake file that calls the function with the provided args
     _cpp_call_fxn_guts("${_cf_fxn2call}" __cpp_call_fxn_file ${ARGN})
     # Include that .cmake file

--- a/cmake/cmakepp_lang/utilities/call_fxn.cmake
+++ b/cmake/cmakepp_lang/utilities/call_fxn.cmake
@@ -16,13 +16,11 @@ include(cmakepp_lang/utilities/decode_special_chars)
 # :param *args: The arguments to forward to the function.
 #]]
 function(_cpp_call_fxn_guts _cfg_fxn2call _cfg_result)
-    message("---- _cpp_call_fxn_guts ARGN: ${ARGN}") # DEBUG
     # Create a new arg list that is a copy of ARGN except all args are
     # surrounded with double quotes (to ensure strings with spaces aren't
     # parsed as lists)
     set(_cfg_args_list "")
     foreach(_cfg_current_arg ${ARGN}) # Loop over all args
-        # message("---- _cpp_call_fxn_guts _cfg_current_arg: ${_cfg_current_arg}") # DEBUG
         string(APPEND _cfg_args_list "\"${_cfg_current_arg}\" ")
     endforeach()
 
@@ -54,7 +52,6 @@ endfunction()
 #    significantly complicate the implementation.
 #]]
 macro(cpp_call_fxn _cf_fxn2call)
-    # message("---- cpp_call_fxn ARGN: ${ARGN}") # DEBUG
     # Create a .cmake file that calls the function with the provided args
     _cpp_call_fxn_guts("${_cf_fxn2call}" __cpp_call_fxn_file ${ARGN})
     # Include that .cmake file

--- a/cmake/cmakepp_lang/utilities/decode_special_chars.cmake
+++ b/cmake/cmakepp_lang/utilities/decode_special_chars.cmake
@@ -7,16 +7,16 @@ include_guard()
 # multiple functions. It is assumed that this will be called on the arguments
 # immediately before the function is finalized and written to a file.
 # 
-# This is necessary because of the way CMake removes the forward slashes 
+# This is nedscsary because of the way CMake removes the forward slashes 
 # escaping the characters as they are passed through as a function parameter, 
 # so users do not have to account for the various function calls being
 # performed in the background when an object method is called.
 #
-# :param _ces_argn: The argument list. This should have at least one string in
+# :param _dsc_argn: The argument list. This should have at least one string in
 #                   it, otherwise this function will have nothing to encode.
-# :type _ces_argn: list
-# :param _ces_return_argn: Return variable for the encoded argument list.
-# :type _ces_return_argn: list
+# :type _dsc_argn: list
+# :param _dsc_return_argn: Return variable for the encoded argument list.
+# :type _dsc_return_argn: list
 # :returns: The list of arguments with special characters encoded.
 # :rtype: list
 #
@@ -27,7 +27,7 @@ include_guard()
 # where arguments will be passed through multiple levels of function calls.
 # This ensures that the escaped special characters are not altered in the
 # string unintentionally and the special characters do not have their escape
-# slashes removed, which could cause unintended consequences.
+# slashes removed, which could cause unintended consequendsc.
 #
 # The special characters need to be decoded again upon reaching their destination.
 #
@@ -40,19 +40,25 @@ include_guard()
 #
 # The only argument to this function should always be ``"${ARGN}``.
 #]]
-function(cpp_decode_special_chars _ces_argn _ces_return_argn)
-    # message("---- cpp_decode_special_chars _ces_argn: ${_ces_argn}") # DEBUG
+function(cpp_decode_special_chars _dsc_argn _dsc_return_argn)
+    # message("---- cpp_decode_special_chars _dsc_argn: ${_dsc_argn}") # DEBUG
 
-    string(ASCII 7 _quote_replace)
+    string(ASCII 6 _quote_replace)
+    string(ASCII 7 _dollar_replace)
+    string(ASCII 11 _at_replace)
+    string(ASCII 12 _semicolon_replace)
 
-    foreach(_arg ${_ces_argn})
+    foreach(_arg ${_dsc_argn})
         # message("       Parsing arg: ${_arg}") # DEBUG
         # Make sure that the special char is actually escaped
         string(REPLACE "${_quote_replace}" "\\\"" _decoded_arg ${_arg})
+        string(REPLACE "${_dollar_replace}" "\\\$" _decoded_arg ${_decoded_arg})
+        string(REPLACE "${_at_replace}" "\\\@" _decoded_arg ${_decoded_arg})
+        string(REPLACE "${_semicolon_replace}" "\\\;" _decoded_arg ${_decoded_arg})
 
         list(APPEND _decoded_args ${_decoded_arg})
         # message("       Decoded to: ${_decoded_arg}") # DEBUG
     endforeach()
 
-    set("${_ces_return_argn}" "${_decoded_args}" PARENT_SCOPE)
+    set("${_dsc_return_argn}" "${_decoded_args}" PARENT_SCOPE)
 endfunction()

--- a/cmake/cmakepp_lang/utilities/decode_special_chars.cmake
+++ b/cmake/cmakepp_lang/utilities/decode_special_chars.cmake
@@ -43,7 +43,6 @@ include(cmakepp_lang/utilities/special_chars_lookup)
 # The only argument to this function should always be ``"${ARGN}``.
 #]]
 function(cpp_decode_special_chars _dsc_argn _dsc_return_argn)
-    # message("---- cpp_decode_special_chars _dsc_argn: ${_dsc_argn}") # DEBUG
 
     cpp_map(GET "${special_chars_lookup}" _quote_replace "dquote")
     cpp_map(GET "${special_chars_lookup}" _dollar_replace "dollar")
@@ -51,7 +50,6 @@ function(cpp_decode_special_chars _dsc_argn _dsc_return_argn)
     cpp_map(GET "${special_chars_lookup}" _bslash_replace "bslash")
 
     foreach(_arg ${_dsc_argn})
-        # message("       Parsing arg: ${_arg}") # DEBUG
         # Make sure that the special char is actually escaped
         string(REPLACE "${_quote_replace}" "\\\"" _decoded_arg ${_arg})
         string(REPLACE "${_bslash_replace}" "\\\\" _decoded_arg ${_decoded_arg})
@@ -59,7 +57,6 @@ function(cpp_decode_special_chars _dsc_argn _dsc_return_argn)
         string(REPLACE "${_semicolon_replace}" "\\\;" _decoded_arg ${_decoded_arg})
 
         list(APPEND _decoded_args ${_decoded_arg})
-        # message("       Decoded to: ${_decoded_arg}") # DEBUG
     endforeach()
 
     set("${_dsc_return_argn}" "${_decoded_args}" PARENT_SCOPE)

--- a/cmake/cmakepp_lang/utilities/decode_special_chars.cmake
+++ b/cmake/cmakepp_lang/utilities/decode_special_chars.cmake
@@ -1,5 +1,7 @@
 include_guard()
 
+include(cmakepp_lang/utilities/special_chars_lookup)
+
 #[[[ Decodes special characters to protect them during function passes.
 #
 # This function decodes special characters that need to be escaped in a CMake
@@ -43,17 +45,17 @@ include_guard()
 function(cpp_decode_special_chars _dsc_argn _dsc_return_argn)
     # message("---- cpp_decode_special_chars _dsc_argn: ${_dsc_argn}") # DEBUG
 
-    string(ASCII 6 _quote_replace)
-    string(ASCII 7 _dollar_replace)
-    string(ASCII 11 _at_replace)
-    string(ASCII 12 _semicolon_replace)
+    cpp_map(GET "${special_chars_lookup}" _quote_replace "dquote")
+    cpp_map(GET "${special_chars_lookup}" _dollar_replace "dollar")
+    cpp_map(GET "${special_chars_lookup}" _semicolon_replace "scolon")
+    cpp_map(GET "${special_chars_lookup}" _fslash_replace "fslash")
 
     foreach(_arg ${_dsc_argn})
         # message("       Parsing arg: ${_arg}") # DEBUG
         # Make sure that the special char is actually escaped
         string(REPLACE "${_quote_replace}" "\\\"" _decoded_arg ${_arg})
+        string(REPLACE "${_fslash_replace}" "\\\\" _decoded_arg ${_decoded_arg})
         string(REPLACE "${_dollar_replace}" "\\\$" _decoded_arg ${_decoded_arg})
-        string(REPLACE "${_at_replace}" "\\\@" _decoded_arg ${_decoded_arg})
         string(REPLACE "${_semicolon_replace}" "\\\;" _decoded_arg ${_decoded_arg})
 
         list(APPEND _decoded_args ${_decoded_arg})

--- a/cmake/cmakepp_lang/utilities/decode_special_chars.cmake
+++ b/cmake/cmakepp_lang/utilities/decode_special_chars.cmake
@@ -48,13 +48,13 @@ function(cpp_decode_special_chars _dsc_argn _dsc_return_argn)
     cpp_map(GET "${special_chars_lookup}" _quote_replace "dquote")
     cpp_map(GET "${special_chars_lookup}" _dollar_replace "dollar")
     cpp_map(GET "${special_chars_lookup}" _semicolon_replace "scolon")
-    cpp_map(GET "${special_chars_lookup}" _fslash_replace "fslash")
+    cpp_map(GET "${special_chars_lookup}" _bslash_replace "bslash")
 
     foreach(_arg ${_dsc_argn})
         # message("       Parsing arg: ${_arg}") # DEBUG
         # Make sure that the special char is actually escaped
         string(REPLACE "${_quote_replace}" "\\\"" _decoded_arg ${_arg})
-        string(REPLACE "${_fslash_replace}" "\\\\" _decoded_arg ${_decoded_arg})
+        string(REPLACE "${_bslash_replace}" "\\\\" _decoded_arg ${_decoded_arg})
         string(REPLACE "${_dollar_replace}" "\\\$" _decoded_arg ${_decoded_arg})
         string(REPLACE "${_semicolon_replace}" "\\\;" _decoded_arg ${_decoded_arg})
 

--- a/cmake/cmakepp_lang/utilities/decode_special_chars.cmake
+++ b/cmake/cmakepp_lang/utilities/decode_special_chars.cmake
@@ -1,0 +1,58 @@
+include_guard()
+
+#[[[ Decodes special characters to protect them during function passes.
+#
+# This function decodes special characters that need to be escaped in a CMake
+# string to protect them while being passed as function parameters through 
+# multiple functions. It is assumed that this will be called on the arguments
+# immediately before the function is finalized and written to a file.
+# 
+# This is necessary because of the way CMake removes the forward slashes 
+# escaping the characters as they are passed through as a function parameter, 
+# so users do not have to account for the various function calls being
+# performed in the background when an object method is called.
+#
+# :param _ces_argn: The argument list. This should have at least one string in
+#                   it, otherwise this function will have nothing to encode.
+# :type _ces_argn: list
+# :param _ces_return_argn: Return variable for the encoded argument list.
+# :type _ces_return_argn: list
+# :returns: The list of arguments with special characters encoded.
+# :rtype: list
+#
+# Example Usage:
+# ==============
+#
+# This function is intended to be called near the top of a function call chain
+# where arguments will be passed through multiple levels of function calls.
+# This ensures that the escaped special characters are not altered in the
+# string unintentionally and the special characters do not have their escape
+# slashes removed, which could cause unintended consequences.
+#
+# The special characters need to be decoded again upon reaching their destination.
+#
+# .. code-block::
+#
+#    include(cmakepp_lang/asserts/signature)
+#    function(my_fxn a_str a_bool)
+#        cpp_encode_special_chars(${ARGN})
+#    endfunction()
+#
+# The only argument to this function should always be ``"${ARGN}``.
+#]]
+function(cpp_decode_special_chars _ces_argn _ces_return_argn)
+    # message("---- cpp_decode_special_chars _ces_argn: ${_ces_argn}") # DEBUG
+
+    string(ASCII 7 _quote_replace)
+
+    foreach(_arg ${_ces_argn})
+        # message("       Parsing arg: ${_arg}") # DEBUG
+        # Make sure that the special char is actually escaped
+        string(REPLACE "${_quote_replace}" "\\\"" _decoded_arg ${_arg})
+
+        list(APPEND _decoded_args ${_decoded_arg})
+        # message("       Decoded to: ${_decoded_arg}") # DEBUG
+    endforeach()
+
+    set("${_ces_return_argn}" "${_decoded_args}" PARENT_SCOPE)
+endfunction()

--- a/cmake/cmakepp_lang/utilities/decode_special_chars.cmake
+++ b/cmake/cmakepp_lang/utilities/decode_special_chars.cmake
@@ -9,10 +9,8 @@ include(cmakepp_lang/utilities/special_chars_lookup)
 # multiple functions. It is assumed that this will be called on the arguments
 # immediately before the function is finalized and written to a file.
 # 
-# This is nedscsary because of the way CMake removes the forward slashes 
-# escaping the characters as they are passed through as a function parameter, 
-# so users do not have to account for the various function calls being
-# performed in the background when an object method is called.
+# The special characters handled are ``$;"\\``. For more information about
+# why this is necessary, see documentation for ``cpp_encode_special_chars``.
 #
 # :param _dsc_argn: The argument list. This should have at least one string in
 #                   it, otherwise this function will have nothing to encode.
@@ -25,30 +23,18 @@ include(cmakepp_lang/utilities/special_chars_lookup)
 # Example Usage:
 # ==============
 #
-# This function is intended to be called near the top of a function call chain
-# where arguments will be passed through multiple levels of function calls.
-# This ensures that the escaped special characters are not altered in the
-# string unintentionally and the special characters do not have their escape
-# slashes removed, which could cause unintended consequendsc.
-#
-# The special characters need to be decoded again upon reaching their destination.
-#
-# .. code-block::
-#
-#    include(cmakepp_lang/asserts/signature)
-#    function(my_fxn a_str a_bool)
-#        cpp_encode_special_chars(${ARGN})
-#    endfunction()
-#
-# The only argument to this function should always be ``"${ARGN}``.
+# See documentation for ``cpp_encode_special_chars`` for usage of both the
+# encoding and decoding functions.
 #]]
 function(cpp_decode_special_chars _dsc_argn _dsc_return_argn)
 
+    # Get the replacement characters from the lookup map
     cpp_map(GET "${special_chars_lookup}" _quote_replace "dquote")
     cpp_map(GET "${special_chars_lookup}" _dollar_replace "dollar")
     cpp_map(GET "${special_chars_lookup}" _semicolon_replace "scolon")
     cpp_map(GET "${special_chars_lookup}" _bslash_replace "bslash")
 
+    # Decode each encoded special character in the arguments
     foreach(_arg ${_dsc_argn})
         # Make sure that the special char is actually escaped
         string(REPLACE "${_quote_replace}" "\\\"" _decoded_arg ${_arg})

--- a/cmake/cmakepp_lang/utilities/encode_special_chars.cmake
+++ b/cmake/cmakepp_lang/utilities/encode_special_chars.cmake
@@ -1,5 +1,7 @@
 include_guard()
 
+include(cmakepp_lang/utilities/special_chars_lookup)
+
 #[[[ Encodes special characters to protect them during function passes.
 #
 # This function encodes special characters that need to be escaped in a CMake
@@ -40,22 +42,22 @@ include_guard()
 #        cpp_encode_special_chars(${ARGN})
 #    endfunction()
 #
-# The only argument to this function should always be ``"${ARGn}``.
+# The only argument to this function should always be ``"${ARGN}``.
 #]]
 function(cpp_encode_special_chars _esc_argn _esc_return_argn)
-    message("---- cpp_encode_special_chars _esc_argn: ${_esc_argn}") # DEBUG
+    # message("---- cpp_encode_special_chars _esc_argn: ${_esc_argn}") # DEBUG
 
-    string(ASCII 6 _quote_replace)
-    string(ASCII 7 _dollar_replace)
-    string(ASCII 11 _at_replace)
-    string(ASCII 12 _semicolon_replace)
+    cpp_map(GET "${special_chars_lookup}" _quote_replace "dquote")
+    cpp_map(GET "${special_chars_lookup}" _dollar_replace "dollar")
+    cpp_map(GET "${special_chars_lookup}" _semicolon_replace "scolon")
+    cpp_map(GET "${special_chars_lookup}" _fslash_replace "fslash")
 
     foreach(_arg ${_esc_argn})
         message("       Parsing arg: ${_arg}") # DEBUG
-        string(REPLACE "\"" "${_quote_replace}" _encoded_arg "${_arg}")
+        string(REPLACE ";" "${_semicolon_replace}" _encoded_arg "${_arg}")
         string(REPLACE "\$" "${_dollar_replace}" _encoded_arg "${_encoded_arg}")
-        string(REPLACE "\@" "${_at_replace}" _encoded_arg "${_encoded_arg}")
-        string(REPLACE "\;" "${_semicolon_replace}" _encoded_arg "${_encoded_arg}")
+        string(REPLACE "\"" "${_quote_replace}" _encoded_arg "${_encoded_arg}")
+        string(REPLACE "\\" "${_fslash_replace}" _encoded_arg "${_encoded_arg}")
 
         list(APPEND _encoded_args "${_encoded_arg}")
         message("       Encoded to: ${_encoded_arg}") # DEBUG

--- a/cmake/cmakepp_lang/utilities/encode_special_chars.cmake
+++ b/cmake/cmakepp_lang/utilities/encode_special_chars.cmake
@@ -50,14 +50,14 @@ function(cpp_encode_special_chars _esc_argn _esc_return_argn)
     cpp_map(GET "${special_chars_lookup}" _quote_replace "dquote")
     cpp_map(GET "${special_chars_lookup}" _dollar_replace "dollar")
     cpp_map(GET "${special_chars_lookup}" _semicolon_replace "scolon")
-    cpp_map(GET "${special_chars_lookup}" _fslash_replace "fslash")
+    cpp_map(GET "${special_chars_lookup}" _bslash_replace "bslash")
 
     foreach(_arg ${_esc_argn})
         message("       Parsing arg: ${_arg}") # DEBUG
         string(REPLACE ";" "${_semicolon_replace}" _encoded_arg "${_arg}")
         string(REPLACE "\$" "${_dollar_replace}" _encoded_arg "${_encoded_arg}")
         string(REPLACE "\"" "${_quote_replace}" _encoded_arg "${_encoded_arg}")
-        string(REPLACE "\\" "${_fslash_replace}" _encoded_arg "${_encoded_arg}")
+        string(REPLACE "\\" "${_bslash_replace}" _encoded_arg "${_encoded_arg}")
 
         list(APPEND _encoded_args "${_encoded_arg}")
         message("       Encoded to: ${_encoded_arg}") # DEBUG

--- a/cmake/cmakepp_lang/utilities/encode_special_chars.cmake
+++ b/cmake/cmakepp_lang/utilities/encode_special_chars.cmake
@@ -11,10 +11,12 @@ include(cmakepp_lang/utilities/special_chars_lookup)
 # function calls, protecting the special characters until they are decoded at
 # their destination.
 # 
-# This is neescsary because of the way CMake removes the forward slashes 
-# escaping the characters as they are passed through as a function parameter, 
-# so users do not have to account for the various function calls being
-# performed in the background when an object method is called.
+# This is necessary because of the way CMake removes the backslashes
+# escaping the characters as they are passed through as a function or macro
+# parameter, so users do not have to account for the various function calls
+# being performed in the background when an object method is called.
+#
+# Specifically, the special characters handled are ``$;"\\``
 #
 # :param _esc_argn: The argument list. This should have at least one string in
 #                   it, otherwise this function will have nothing to encode.
@@ -42,7 +44,7 @@ include(cmakepp_lang/utilities/special_chars_lookup)
 #        cpp_encode_special_chars(${ARGN})
 #    endfunction()
 #
-# The only argument to this function should always be ``"${ARGN}``.
+# The only argument to this function should always be ``"${ARGN}"``.
 #]]
 function(cpp_encode_special_chars _esc_argn _esc_return_argn)
 

--- a/cmake/cmakepp_lang/utilities/encode_special_chars.cmake
+++ b/cmake/cmakepp_lang/utilities/encode_special_chars.cmake
@@ -45,7 +45,6 @@ include(cmakepp_lang/utilities/special_chars_lookup)
 # The only argument to this function should always be ``"${ARGN}``.
 #]]
 function(cpp_encode_special_chars _esc_argn _esc_return_argn)
-    # message("---- cpp_encode_special_chars _esc_argn: ${_esc_argn}") # DEBUG
 
     cpp_map(GET "${special_chars_lookup}" _quote_replace "dquote")
     cpp_map(GET "${special_chars_lookup}" _dollar_replace "dollar")
@@ -53,14 +52,12 @@ function(cpp_encode_special_chars _esc_argn _esc_return_argn)
     cpp_map(GET "${special_chars_lookup}" _bslash_replace "bslash")
 
     foreach(_arg ${_esc_argn})
-        message("       Parsing arg: ${_arg}") # DEBUG
         string(REPLACE ";" "${_semicolon_replace}" _encoded_arg "${_arg}")
         string(REPLACE "\$" "${_dollar_replace}" _encoded_arg "${_encoded_arg}")
         string(REPLACE "\"" "${_quote_replace}" _encoded_arg "${_encoded_arg}")
         string(REPLACE "\\" "${_bslash_replace}" _encoded_arg "${_encoded_arg}")
 
         list(APPEND _encoded_args "${_encoded_arg}")
-        message("       Encoded to: ${_encoded_arg}") # DEBUG
     endforeach()
 
     set("${_esc_return_argn}" "${_encoded_args}" PARENT_SCOPE)

--- a/cmake/cmakepp_lang/utilities/encode_special_chars.cmake
+++ b/cmake/cmakepp_lang/utilities/encode_special_chars.cmake
@@ -1,0 +1,59 @@
+include_guard()
+
+#[[[ Encodes special characters to protect them during function passes.
+#
+# This function encodes special characters that need to be escaped in a CMake
+# string to protect them while being passed as function parameters through 
+# multiple functions. It is assumed that this will be called on the arguments
+# immediately after they are passed into the first function in a series of 
+# function calls, protecting the special characters until they are decoded at
+# their destination.
+# 
+# This is neescsary because of the way CMake removes the forward slashes 
+# escaping the characters as they are passed through as a function parameter, 
+# so users do not have to account for the various function calls being
+# performed in the background when an object method is called.
+#
+# :param _esc_argn: The argument list. This should have at least one string in
+#                   it, otherwise this function will have nothing to encode.
+# :type _esc_argn: list
+# :param _esc_return_argn: Return variable for the encoded argument list.
+# :type _esc_return_argn: list
+# :returns: The list of arguments with special characters encoded.
+# :rtype: list
+#
+# Example Usage:
+# ==============
+#
+# This function is intended to be called near the top of a function call chain
+# where arguments will be passed through multiple levels of function calls.
+# This ensures that the escaped special characters are not altered in the
+# string unintentionally and the special characters do not have their escape
+# slashes removed, which could cause unintended consequenesc.
+#
+# The special characters need to be decoded again upon reaching their destination.
+#
+# .. code-block::
+#
+#    include(cmakepp_lang/asserts/signature)
+#    function(my_fxn a_str a_bool)
+#        cpp_encode_special_chars(${ARGN})
+#    endfunction()
+#
+# The only argument to this function should always be ``"${ARGn}``.
+#]]
+function(cpp_encode_special_chars _esc_argn _esc_return_argn)
+    # message("---- cpp_encode_special_chars _esc_argn: ${_esc_argn}") # DEBUG
+
+    string(ASCII 7 _quote_replace)
+
+    foreach(_arg ${_esc_argn})
+        # message("       Parsing arg: ${_arg}") # DEBUG
+        string(REPLACE "\"" "${_quote_replace}" _encoded_arg "${_arg}")
+
+        list(APPEND _encoded_args "${_encoded_arg}")
+        # message("       Encoded to: ${_encoded_arg}") # DEBUG
+    endforeach()
+
+    set("${_esc_return_argn}" "${_encoded_args}" PARENT_SCOPE)
+endfunction()

--- a/cmake/cmakepp_lang/utilities/encode_special_chars.cmake
+++ b/cmake/cmakepp_lang/utilities/encode_special_chars.cmake
@@ -43,16 +43,22 @@ include_guard()
 # The only argument to this function should always be ``"${ARGn}``.
 #]]
 function(cpp_encode_special_chars _esc_argn _esc_return_argn)
-    # message("---- cpp_encode_special_chars _esc_argn: ${_esc_argn}") # DEBUG
+    message("---- cpp_encode_special_chars _esc_argn: ${_esc_argn}") # DEBUG
 
-    string(ASCII 7 _quote_replace)
+    string(ASCII 6 _quote_replace)
+    string(ASCII 7 _dollar_replace)
+    string(ASCII 11 _at_replace)
+    string(ASCII 12 _semicolon_replace)
 
     foreach(_arg ${_esc_argn})
-        # message("       Parsing arg: ${_arg}") # DEBUG
+        message("       Parsing arg: ${_arg}") # DEBUG
         string(REPLACE "\"" "${_quote_replace}" _encoded_arg "${_arg}")
+        string(REPLACE "\$" "${_dollar_replace}" _encoded_arg "${_encoded_arg}")
+        string(REPLACE "\@" "${_at_replace}" _encoded_arg "${_encoded_arg}")
+        string(REPLACE "\;" "${_semicolon_replace}" _encoded_arg "${_encoded_arg}")
 
         list(APPEND _encoded_args "${_encoded_arg}")
-        # message("       Encoded to: ${_encoded_arg}") # DEBUG
+        message("       Encoded to: ${_encoded_arg}") # DEBUG
     endforeach()
 
     set("${_esc_return_argn}" "${_encoded_args}" PARENT_SCOPE)

--- a/cmake/cmakepp_lang/utilities/special_chars_lookup.cmake
+++ b/cmake/cmakepp_lang/utilities/special_chars_lookup.cmake
@@ -13,5 +13,5 @@ cpp_map(CTOR special_chars_lookup
     "dquote" "${_scl_enquiry}"
     "dollar" "${_scl_acknowledge}"
     "scolon" "${_scl_bell}"
-    "fslash" "${_scl_data_link_escape}"
+    "bslash" "${_scl_data_link_escape}"
 )

--- a/cmake/cmakepp_lang/utilities/special_chars_lookup.cmake
+++ b/cmake/cmakepp_lang/utilities/special_chars_lookup.cmake
@@ -1,0 +1,17 @@
+include_guard()
+
+string(ASCII 5 _scl_enquiry)
+string(ASCII 6 _scl_acknowledge)
+string(ASCII 7 _scl_bell)
+string(ASCII 16 _scl_data_link_escape)
+string(ASCII 17 _scl_device_control_1)
+string(ASCII 18 _scl_device_control_2)
+string(ASCII 19 _scl_device_control_3)
+string(ASCII 20 _scl_device_control_4)
+
+cpp_map(CTOR special_chars_lookup
+    "dquote" "${_scl_enquiry}"
+    "dollar" "${_scl_acknowledge}"
+    "scolon" "${_scl_bell}"
+    "fslash" "${_scl_data_link_escape}"
+)

--- a/tests/object/str_arg.cmake
+++ b/tests/object/str_arg.cmake
@@ -35,6 +35,10 @@ function("${test_str_arg_w_escaped_chars}")
         MyClass(print_msg "${my_obj}" "\"\"\"\"\"\"\"\"\"\"")
         ct_assert_prints("\"\"\"\"\"\"\"\"\"\"")
 
+        set(a_var "String \"with quotes\"")
+        MyClass(print_msg "${my_obj}" "${a_var}")
+        ct_assert_prints("String \"with quotes\"")
+
     endfunction()
 
     ct_add_section(NAME "test_escaped_dollar")
@@ -50,6 +54,10 @@ function("${test_str_arg_w_escaped_chars}")
 
         MyClass(print_msg "${my_obj}" "\$\$\$\$\$\$\$\$\$\$")
         ct_assert_prints("\$\$\$\$\$\$\$\$\$\$")
+
+        set(a_var "String \$with dollar\$")
+        MyClass(print_msg "${my_obj}" "${a_var}")
+        ct_assert_prints("String \$with dollar\$")
 
     endfunction()
 

--- a/tests/object/str_arg.cmake
+++ b/tests/object/str_arg.cmake
@@ -146,10 +146,10 @@ function("${test_str_arg_w_escaped_chars}")
         MyClass(print_msg "${my_obj}" "test {var}")
         ct_assert_prints("test {var}")
 
-        MyClass(print_msg "${my_obj}" "test #var")
+        MyClass(print_msg "${my_obj}" "test #var#")
         ct_assert_prints("test #var")
 
-        MyClass(print_msg "${my_obj}" "test 'var")
+        MyClass(print_msg "${my_obj}" "test 'var'")
         ct_assert_prints("test 'var")
 
         MyClass(print_msg "${my_obj}" "test @var@")
@@ -157,6 +157,9 @@ function("${test_str_arg_w_escaped_chars}")
 
         MyClass(print_msg "${my_obj}" "test ^var^")
         ct_assert_prints("test ^var^")
+
+        MyClass(print_msg "${my_obj}" "test /var/")
+        ct_assert_prints("test /var/")
 
     endfunction()
 

--- a/tests/object/str_arg.cmake
+++ b/tests/object/str_arg.cmake
@@ -161,6 +161,9 @@ function("${test_str_arg_w_escaped_chars}")
         MyClass(print_msg "${my_obj}" "test /var/")
         ct_assert_prints("test /var/")
 
+        MyClass(print_msg "${my_obj}" "test &var&")
+        ct_assert_prints("test &var&")
+
     endfunction()
 
     ct_add_section(NAME "test_multiple_args")

--- a/tests/object/str_arg.cmake
+++ b/tests/object/str_arg.cmake
@@ -15,8 +15,8 @@ cpp_class(MyClass)
 ct_add_test(NAME "test_str_arg_w_escaped_chars")
 function("${test_str_arg_w_escaped_chars}")
 
-    ct_add_section(NAME "test_escaped_quotes")
-    function("${test_escaped_quotes}")
+    ct_add_section(NAME "test_no_escapes")
+    function("${test_no_escapes}")
 
         MyClass(CTOR my_obj)
 
@@ -25,6 +25,13 @@ function("${test_str_arg_w_escaped_chars}")
 
         MyClass(print_msg "${my_obj}" "test string")
         ct_assert_prints("test string")
+
+    endfunction()
+
+    ct_add_section(NAME "test_escaped_quotes")
+    function("${test_escaped_quotes}")
+
+        MyClass(CTOR my_obj)
 
         MyClass(print_msg "${my_obj}" "test \"string")
         ct_assert_prints("test \"string")
@@ -58,6 +65,84 @@ function("${test_str_arg_w_escaped_chars}")
         set(a_var "String \$with dollar\$")
         MyClass(print_msg "${my_obj}" "${a_var}")
         ct_assert_prints("String \$with dollar\$")
+
+    endfunction()
+
+    ct_add_section(NAME "test_escaped_semicolon")
+    function("${test_escaped_semicolon}")
+
+        MyClass(CTOR my_obj)
+
+        MyClass(print_msg "${my_obj}" "test \;semicolon")
+        ct_assert_prints("test \;semicolon")
+
+        MyClass(print_msg "${my_obj}" "String \;with semicolon\;")
+        ct_assert_prints("String \;with semicolon\;")
+
+        MyClass(print_msg "${my_obj}" "\;\;\;\;\;\;\;\;\;\;")
+        ct_assert_prints("\;\;\;\;\;\;\;\;\;\;")
+
+        set(a_var "String \;with semicolon\;")
+        MyClass(print_msg "${my_obj}" "${a_var}")
+        ct_assert_prints("String \;with semicolon\;")
+
+    endfunction()
+
+    ct_add_section(NAME "test_escaped_var_ref")
+    function("${test_escaped_var_ref}")
+
+        MyClass(CTOR my_obj)
+
+        MyClass(print_msg "${my_obj}" "test \\\${var}")
+        ct_assert_prints("test \${var}")
+
+        MyClass(print_msg "${my_obj}" "test \\\${var}")
+        ct_assert_prints("test \${var}")
+
+        MyClass(print_msg "${my_obj}" "\\\${var}\\\${var}\\\${var}\\\${var}\\\${var}\\\${var}\\\${var}\\\${var}\\\${var}\\\${var}")
+        ct_assert_prints("\${var}\${var}\${var}\${var}\${var}\${var}\${var}\${var}\${var}\${var}")
+
+        set(a_var "test \\\${var}")
+        MyClass(print_msg "${my_obj}" "${a_var}")
+        ct_assert_prints("test \${var}")
+
+    endfunction()
+
+    ct_add_section(NAME "test_other_chars")
+    function("${test_other_chars}")
+
+        MyClass(CTOR my_obj)
+
+        MyClass(print_msg "${my_obj}" "test (var)")
+        ct_assert_prints("test (var)")
+        
+        MyClass(print_msg "${my_obj}" "test {var{")
+        ct_assert_prints("test {var{")
+
+        MyClass(print_msg "${my_obj}" "test }var}")
+        ct_assert_prints("test }var}")
+
+        MyClass(print_msg "${my_obj}" "test {var}")
+        ct_assert_prints("test {var}")
+
+        MyClass(print_msg "${my_obj}" "test #var")
+        ct_assert_prints("test #var")
+
+        MyClass(print_msg "${my_obj}" "test 'var")
+        ct_assert_prints("test 'var")
+
+        # Invalid character escape '\v'
+        # MyClass(print_msg "${my_obj}" "test \\var")
+        # ct_assert_prints("test \\var")
+
+        MyClass(print_msg "${my_obj}" "test \\\\var")
+        ct_assert_prints("test \\\\var")
+
+        MyClass(print_msg "${my_obj}" "test @var@")
+        ct_assert_prints("test @var@")
+
+        MyClass(print_msg "${my_obj}" "test ^var^")
+        ct_assert_prints("test ^var^")
 
     endfunction()
 

--- a/tests/object/str_arg.cmake
+++ b/tests/object/str_arg.cmake
@@ -88,13 +88,34 @@ function("${test_str_arg_w_escaped_chars}")
 
     endfunction()
 
+    ct_add_section(NAME "test_escaped_backslash")
+    function("${test_escaped_backslash}")
+
+        MyClass(CTOR my_obj)
+
+        # Invalid character escape '\v'
+        # MyClass(print_msg "${my_obj}" "test \\var")
+        # ct_assert_prints("test \\var")
+
+        MyClass(print_msg "${my_obj}" "test \\\\backslash")
+        ct_assert_prints("test \\backslash")
+
+        MyClass(print_msg "${my_obj}" "test \\\\backslash\\\\")
+        ct_assert_prints("test \\backslash\\")
+
+        MyClass(print_msg "${my_obj}" "\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\")
+        ct_assert_prints("\\\\\\\\\\\\\\\\\\\\")
+
+        set(a_var "test \\\\backslash\\\\")
+        MyClass(print_msg "${my_obj}" "${a_var}")
+        ct_assert_prints("test \\backslash\\")
+
+    endfunction()
+
     ct_add_section(NAME "test_escaped_var_ref")
     function("${test_escaped_var_ref}")
 
         MyClass(CTOR my_obj)
-
-        MyClass(print_msg "${my_obj}" "test \\\${var}")
-        ct_assert_prints("test \${var}")
 
         MyClass(print_msg "${my_obj}" "test \\\${var}")
         ct_assert_prints("test \${var}")
@@ -130,13 +151,6 @@ function("${test_str_arg_w_escaped_chars}")
 
         MyClass(print_msg "${my_obj}" "test 'var")
         ct_assert_prints("test 'var")
-
-        # Invalid character escape '\v'
-        # MyClass(print_msg "${my_obj}" "test \\var")
-        # ct_assert_prints("test \\var")
-
-        MyClass(print_msg "${my_obj}" "test \\\\var")
-        ct_assert_prints("test \\\\var")
 
         MyClass(print_msg "${my_obj}" "test @var@")
         ct_assert_prints("test @var@")

--- a/tests/object/str_arg.cmake
+++ b/tests/object/str_arg.cmake
@@ -1,0 +1,40 @@
+include(cmake_test/cmake_test)
+
+cpp_class(MyClass)
+
+    cpp_member(print_msg MyClass str)
+    function("${print_msg}" self test_string)
+
+        message("---- ${test_string}")
+
+    endfunction()
+
+# Don't end the class so methods can be defined in the tests
+# cpp_end_class()
+
+ct_add_test(NAME "test_str_arg_w_escaped_chars")
+function("${test_str_arg_w_escaped_chars}")
+
+    ct_add_section(NAME "test_escaped_quotes")
+    function("${test_escaped_quotes}")
+
+        MyClass(CTOR my_obj)
+
+        MyClass(print_msg "${my_obj}" "teststring")
+        ct_assert_prints("teststring")
+
+        MyClass(print_msg "${my_obj}" "test string")
+        ct_assert_prints("test string")
+
+        MyClass(print_msg "${my_obj}" "test \"string")
+        ct_assert_prints("test \"string")
+
+        MyClass(print_msg "${my_obj}" "String \"with quotes\"")
+        ct_assert_prints("String \"with quotes\"")
+
+        MyClass(print_msg "${my_obj}" "\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"")
+        ct_assert_prints("\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"")
+
+    endfunction()
+
+endfunction()

--- a/tests/object/str_arg.cmake
+++ b/tests/object/str_arg.cmake
@@ -5,7 +5,7 @@ cpp_class(MyClass)
     cpp_member(print_msg MyClass str)
     function("${print_msg}" self test_string)
 
-        message("---- ${test_string}")
+        message("${test_string}")
 
     endfunction()
 
@@ -34,6 +34,51 @@ function("${test_str_arg_w_escaped_chars}")
 
         MyClass(print_msg "${my_obj}" "\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"")
         ct_assert_prints("\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"")
+
+    endfunction()
+
+    ct_add_section(NAME "test_multiple_args")
+    function("${test_multiple_args}")
+
+        ct_add_section(NAME "test_two_args")
+        function("${test_two_args}")
+            cpp_member(print_msg MyClass int str)
+            function("${print_msg}" self test_int test_string)
+
+                message("${test_string}")
+
+            endfunction()
+
+            cpp_member(print_msg MyClass str int)
+            function("${print_msg}" self test_string test_int)
+
+                message("---- ${test_string}")
+
+            endfunction()
+
+            MyClass(CTOR my_obj)
+
+            MyClass(print_msg "${my_obj}" "\"" 42)
+            ct_assert_prints("\"")
+
+            MyClass(print_msg "${my_obj}" 42 "\"")
+            ct_assert_prints("\"")
+        endfunction()
+
+        ct_add_section(NAME "test_three_args")
+        function("${test_three_args}")
+            cpp_member(print_msg MyClass int str int)
+            function("${print_msg}" self test_int test_string test_int2)
+
+                message("${test_string}")
+
+            endfunction()
+
+            MyClass(CTOR my_obj)
+
+            MyClass(print_msg "${my_obj}" 42 "\"" 2)
+            ct_assert_prints("\"")
+        endfunction()
 
     endfunction()
 

--- a/tests/object/str_arg.cmake
+++ b/tests/object/str_arg.cmake
@@ -32,8 +32,24 @@ function("${test_str_arg_w_escaped_chars}")
         MyClass(print_msg "${my_obj}" "String \"with quotes\"")
         ct_assert_prints("String \"with quotes\"")
 
-        MyClass(print_msg "${my_obj}" "\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"")
-        ct_assert_prints("\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"")
+        MyClass(print_msg "${my_obj}" "\"\"\"\"\"\"\"\"\"\"")
+        ct_assert_prints("\"\"\"\"\"\"\"\"\"\"")
+
+    endfunction()
+
+    ct_add_section(NAME "test_escaped_quotes")
+    function("${test_escaped_quotes}")
+
+        MyClass(CTOR my_obj)
+
+        MyClass(print_msg "${my_obj}" "test \$dollar")
+        ct_assert_prints("test \$dollar")
+
+        MyClass(print_msg "${my_obj}" "String \$with dollar\$")
+        ct_assert_prints("String \$with dollar\$")
+
+        MyClass(print_msg "${my_obj}" "\$\$\$\$\$\$\$\$\$\$")
+        ct_assert_prints("\$\$\$\$\$\$\$\$\$\$")
 
     endfunction()
 
@@ -52,17 +68,17 @@ function("${test_str_arg_w_escaped_chars}")
             cpp_member(print_msg MyClass str int)
             function("${print_msg}" self test_string test_int)
 
-                message("---- ${test_string}")
+                message("${test_string}")
 
             endfunction()
 
             MyClass(CTOR my_obj)
 
-            MyClass(print_msg "${my_obj}" "\"" 42)
-            ct_assert_prints("\"")
+            MyClass(print_msg "${my_obj}" "\"\$" 42)
+            ct_assert_prints("\"\$")
 
-            MyClass(print_msg "${my_obj}" 42 "\"")
-            ct_assert_prints("\"")
+            MyClass(print_msg "${my_obj}" 42 "\"\$")
+            ct_assert_prints("\"\$")
         endfunction()
 
         ct_add_section(NAME "test_three_args")
@@ -76,8 +92,8 @@ function("${test_str_arg_w_escaped_chars}")
 
             MyClass(CTOR my_obj)
 
-            MyClass(print_msg "${my_obj}" 42 "\"" 2)
-            ct_assert_prints("\"")
+            MyClass(print_msg "${my_obj}" 42 "\"\$" 2)
+            ct_assert_prints("\"\$")
         endfunction()
 
     endfunction()

--- a/tests/object/str_arg.cmake
+++ b/tests/object/str_arg.cmake
@@ -37,8 +37,8 @@ function("${test_str_arg_w_escaped_chars}")
 
     endfunction()
 
-    ct_add_section(NAME "test_escaped_quotes")
-    function("${test_escaped_quotes}")
+    ct_add_section(NAME "test_escaped_dollar")
+    function("${test_escaped_dollar}")
 
         MyClass(CTOR my_obj)
 


### PR DESCRIPTION
Fixes #46, where escaped special characters were being deprotected as they passed through the various function calls made during the execution of an object method call. The solution to be implemented is to protect the special characters as soon as they are passed into the object method call as benign, untype-able (or at least not easily typed) ASCII characters, like ASCII character 7, the BEL character. Then, they will be decoded again immediately before execution.

Steps to complete this PR:
- [x] Create encoding and decoding functions for escaped double quotes.
- [x] Unit test the encoding and decoding functions.
- [x] Put the functions in the right places.
- [x] Expand the encoding and decoding to other special characters.
- [x] Clean up debug statements!
- [x] Make sure documentation is complete.