### PR TITLE
Disambiguate 'cpp_map' key variable and key names

### DIFF
--- a/cmake/cmakepp_lang/map/map.cmake
+++ b/cmake/cmakepp_lang/map/map.cmake
@@ -40,7 +40,7 @@ function(cpp_map_append _ma_this _ma_key _ma_value)
     cpp_assert_signature("${ARGV}" map str str)
 
     cpp_append_global("${_ma_this}_keys" "${_ma_key}")
-    cpp_append_global("${_ma_this}_${_ma_key}" "${_ma_value}")
+    cpp_append_global("${_ma_this}_keys_${_ma_key}" "${_ma_value}")
 endfunction()
 
 #[[[ Constructs a new Map instance with the specified state (if provided)
@@ -119,7 +119,7 @@ endfunction()
 function(cpp_map_get _mg_this _mg_value _mg_key)
     cpp_assert_signature("${ARGV}" map desc str)
 
-    cpp_get_global("${_mg_value}" "${_mg_this}_${_mg_key}")
+    cpp_get_global("${_mg_value}" "${_mg_this}_keys_${_mg_key}")
     cpp_return("${_mg_value}")
 endfunction()
 
@@ -152,7 +152,7 @@ function(cpp_map_set _ms_this _ms_key _ms_value)
     cpp_assert_signature("${ARGV}" map str str args)
 
     cpp_append_global("${_ms_this}_keys" "${_ms_key}")
-    cpp_set_global("${_ms_this}_${_ms_key}" "${_ms_value}")
+    cpp_set_global("${_ms_this}_keys_${_ms_key}" "${_ms_value}")
 
     if("${ARGC}" GREATER 3)
         cpp_map_set("${_ms_this}" ${ARGN})

--- a/tests/map/test_map.cmake
+++ b/tests/map/test_map.cmake
@@ -63,11 +63,8 @@ function("${test_cpp_map}")
         ct_assert_equal(result TRUE)
     endfunction()
 
-    #Setting name as "keys" conflicts
-    #with cpp_map's list of keys
-    #and causes data corruption
-    ct_add_section(NAME "test_keys")
-    function("${test_keys}")
+    ct_add_section(NAME "keys")
+    function("${keys}")
         cpp_map(CTOR a_map foo bar)
         cpp_map(KEYS "${a_map}" map_keys)
         ct_assert_equal(map_keys foo)


### PR DESCRIPTION
Fixes #48. Disambiguates the names of the variable used to store key names in a `cpp_map` and the variables that store values for the keys. See issue #48 for the proposed naming fix that was implemented. 

The test where the bug was discovered, `test_keys` under `test_cpp_map` in `tests/map/test_map.cmake` was reverted to the name `keys` to ensure that this fix worked.