### PR TITLE
Encode escaped special characters in 'cpp_call_fxn' arguments

### DIFF
--- a/cmake/cmakepp_lang/utilities/call_fxn.cmake
+++ b/cmake/cmakepp_lang/utilities/call_fxn.cmake
@@ -52,8 +52,10 @@ endfunction()
 #    significantly complicate the implementation.
 #]]
 macro(cpp_call_fxn _cf_fxn2call)
+    # Encode special characters to protect them from getting un-escaped
+    cpp_encode_special_chars("${ARGN}" _cf_encoded_args)
     # Create a .cmake file that calls the function with the provided args
-    _cpp_call_fxn_guts("${_cf_fxn2call}" __cpp_call_fxn_file ${ARGN})
+    _cpp_call_fxn_guts("${_cf_fxn2call}" __cpp_call_fxn_file ${_cf_encoded_args})
     # Include that .cmake file
     include("${__cpp_call_fxn_file}")
 endmacro()

--- a/tests/utilities/call_fxn.cmake
+++ b/tests/utilities/call_fxn.cmake
@@ -40,4 +40,20 @@ function("${test_cpp_call_fxn}")
         endfunction()
 
     endfunction()
+
+    # This test will crash if it isn't working properly
+    ct_add_section(NAME "unmatched_escaped_quotes")
+    function("${unmatched_escaped_quotes}")
+        cpp_catch(TEST_EXCEPTION)
+
+        function("${TEST_EXCEPTION}" message)
+            message("This does not execute")
+        endfunction()
+
+        cpp_raise(TEST_EXCEPTION "\"test")
+
+        ct_assert_prints("This does not execute")
+    endfunction()
 endfunction()
+
+


### PR DESCRIPTION
Fixes #52 by adding a call to `cpp_encode_special_chars()` to the top of the `cpp_call_fxn()` macro. This will protect special characters so the escaping backslashes are not removed, which would cause unintended consequences.