### PR TITLE
Document 'cpp_return' more

### DIFF
--- a/cmake/cmakepp_lang/utilities/return.cmake
+++ b/cmake/cmakepp_lang/utilities/return.cmake
@@ -37,7 +37,7 @@ include_guard()
 #    function(fxn_name return_identifier)
 #        set(${return_identifier} "some value"
 #        if(x)
-#            set(${return_identifier} "anoter value")
+#            set(${return_identifier} "another value")
 #            cpp_return(${return_identifier})
 #        endif()
 #        cpp_return(${return_indentifier})

--- a/cmake/cmakepp_lang/utilities/return.cmake
+++ b/cmake/cmakepp_lang/utilities/return.cmake
@@ -35,12 +35,12 @@ include_guard()
 # .. code-block:: cmake
 #
 #    function(fxn_name return_identifier)
-#        set(${return_identifier} "some value"
+#        set(${return_identifier} "some value")
 #        if(x)
 #            set(${return_identifier} "another value")
 #            cpp_return(${return_identifier})
 #        endif()
-#        cpp_return(${return_indentifier})
+#        cpp_return(${return_identifier})
 #    endfunction()
 #
 #]]

--- a/docs/source/features/utilities.rst
+++ b/docs/source/features/utilities.rst
@@ -10,6 +10,7 @@ The CMakePP language provides the following utility commands:
 - ``cpp_contains`` for checking if a string contains a certain substring, a list
   contains a certain item, or a map contains a certain key
 - ``cpp_type_of`` for determining the type of a variable
+- ``cpp_return`` for returning a value from a function
 - ``cpp_assert`` for asserting that a condition is true and stopping the
   build process if that condition is not true
 - ``cpp_directory_exists`` for checking that a directory at a given path

--- a/docs/source/getting_started/cmakepp_examples/utilities.rst
+++ b/docs/source/getting_started/cmakepp_examples/utilities.rst
@@ -100,6 +100,20 @@ variable or value:
 
   ``cpp_type_of`` works with CMakePP types as well as native CMake types.
 
+Returning a Value
+=================
+
+We can use ``cpp_return`` to return a value from a function:
+
+.. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/utilities/return.cmake
+   :lines: 3-11
+
+The function can then be called with:
+
+.. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/utilities/return.cmake
+   :lines: 15-19
+   :dedent: 4
+
 Asserting a Condition
 =====================
 

--- a/tests/docs/source/getting_started/cmakepp_examples/utilities/return.cmake
+++ b/tests/docs/source/getting_started/cmakepp_examples/utilities/return.cmake
@@ -1,0 +1,23 @@
+include(cmake_test/cmake_test)
+
+# Define a function with a return value
+function(fxn_with_return return_identifier)
+
+    set("${return_identifier}" "test_value")
+
+    cpp_return("${return_identifier}")
+
+endfunction()
+
+ct_add_test(NAME "return")
+function("${return}")
+
+    # Calling the function
+    fxn_with_return(return_value)
+
+    message("${return_value}")
+    # OUTPUT: test_value
+
+    ct_assert_equal(return_value "test_value")
+
+endfunction()


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
This PR adds more documentation for the `cpp_return` function with tested code examples.

Currently, `cpp_return` is not listed under the [available utilities](https://cmakepp.github.io/CMakePPLang/features/utilities.html). It also does not have an entry in the ["Using Utilities" section](https://cmakepp.github.io/CMakePPLang/getting_started/cmakepp_examples/utilities.html). The only example is in the "Getting Started" section for classes [here](https://cmakepp.github.io/CMakePPLang/getting_started/cmakepp_examples/classes.html#returning-a-value-from-a-function).

**TODOs**
- [x] Add to the list of [available utilities](https://cmakepp.github.io/CMakePPLang/features/utilities.html)
- [x] Add example to the ["Using Utilities" section](https://cmakepp.github.io/CMakePPLang/getting_started/cmakepp_examples/utilities.html)
- [x] Test the example code
