### PR TITLE
Document case insensitive user class names

### DIFF
--- a/docs/source/features/classes.rst
+++ b/docs/source/features/classes.rst
@@ -16,8 +16,11 @@ Class Definition
 ================
 
 Class definitions start with ``cpp_class(MyClass)`` where ``MyClass`` is what
-you want to name the class. Class definitions are ended with
-``cpp_end_class()``. The following is an example of an empty class definition:
+you want to name the class. CMakePPLang handles the class name, ``MyClass``
+case-insensitively, so ``myclass`` and ``MYCLASS`` will also refer to the
+same class created through ``cpp_class(MyClass)``. Class definitions are
+ended with ``cpp_end_class()``. The following is an example of an empty
+class definition:
 
 .. code-block:: cmake
 

--- a/docs/source/getting_started/cmakepp_examples/classes.rst
+++ b/docs/source/getting_started/cmakepp_examples/classes.rst
@@ -28,7 +28,7 @@ color attribute, and print out that value:
 We can also set the value of the attribute:
 
 .. literalinclude:: /../../tests/docs/source/getting_started/cmakepp_examples/classes/writing_basic_class.cmake
-   :lines: 26-35
+   :lines: 28-37
    :dedent: 4
 
 See :ref:`features-classes` for more information about CMakePP classes.

--- a/docs/source/getting_started/cmakepp_examples/classes.rst
+++ b/docs/source/getting_started/cmakepp_examples/classes.rst
@@ -31,6 +31,12 @@ We can also set the value of the attribute:
    :lines: 28-37
    :dedent: 4
 
+.. note::
+
+   Class names are case-insensitive, so ``Automobile``, ``automobile``, and
+   ``AUTOMOBILE`` are all valid ways to refer to the class, as shown in
+   the last code snippet above.
+
 See :ref:`features-classes` for more information about CMakePP classes.
 
 .. _examples-classes-member-functions:

--- a/tests/docs/source/getting_started/cmakepp_examples/classes/writing_basic_class.cmake
+++ b/tests/docs/source/getting_started/cmakepp_examples/classes/writing_basic_class.cmake
@@ -23,15 +23,19 @@ function("${writing_basic_class}")
 
     # Output: The color of my_auto is: red
 
+    ct_assert_equal(my_autos_color "red")
+
     # Set a new value for the "color" attribute
     Automobile(SET "${my_auto}" color blue)
 
-    # Access the "color" attribute again and save it to the var "my_autos_color"
-    Automobile(GET "${my_auto}" my_autos_color color)
+    # User-defined class names are case-insensitive, so lowercase works, too
+    automobile(GET "${my_auto}" my_autos_color color)
 
     # Print out the value of the var "my_autos_color"
     message("The color of my_auto is: ${my_autos_color}")
 
     # Output: The color of my_auto is: blue
+
+    ct_assert_equal(my_autos_color "blue")
 
 endfunction()


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
User-defined class names are case-insensitive, however, this is not mentioned where a user will commonly first encounter classes in the documentation ([here ](https://cmakepp.github.io/CMakePPLang/features/classes.html#features-classes) and [here](https://cmakepp.github.io/CMakePPLang/features/classes.html#features-classes)). This PR adds notes mentioning this case-insensitivity to those documents to help ensure a user is aware of it.
