### PR TITLE
Check if user-defined class names conflict with built-in data types

### DIFF
--- a/cmake/cmakepp_lang/class/class.cmake
+++ b/cmake/cmakepp_lang/class/class.cmake
@@ -2,6 +2,7 @@ include_guard()
 include(cmakepp_lang/class/detail_/bases)
 include(cmakepp_lang/object/object)
 include(cmakepp_lang/types/cmakepp_type)
+include(cmakepp_lang/utilities/check_conflicting_types)
 
 set(
     __CMAKEPP_LANG_CLASS_TEMPLATE__
@@ -25,6 +26,16 @@ set(
 # :rtype: path
 #]]
 function(_cpp_class_guts _cg_type _cg_wrapper)
+    cpp_sanitize_string(_cg_nice_type "${_cg_type}")
+    cpp_check_conflicts(_cg_conflict _cg_conflicting_type "${_cg_nice_type}")
+    if(_cg_conflict)
+        message(
+            FATAL_ERROR
+            "Class name conflicts with a built-in type: "
+            "'${_cg_type}' conflicts with built-in '${_cg_conflicting_type}'"
+        )
+    endif()
+
     if("${ARGC}" EQUAL 2)
         # No parent classes passed in, only inherit from obj
         set(_cg_bases "obj")

--- a/cmake/cmakepp_lang/utilities/check_conflicting_types.cmake
+++ b/cmake/cmakepp_lang/utilities/check_conflicting_types.cmake
@@ -1,0 +1,50 @@
+include_guard()
+
+#[[[ Checks if the given name conflicts with any built-in CMakePPLang types.
+#
+# :param _cc_conflict: Return value for whether a conflict exists.
+# :type _cc_conflict: bool*
+# :param _cc_conflicting_type: Return value for the type that the name
+#                              conflicts with.
+# :type _cc_conflicting_type: desc*
+# :param _cc_name: Name to check for conflicts with.
+# :type _cc_name: desc
+#
+# :returns: Whether there was a conflict (TRUE) or not (FALSE) and the
+#           conflicting type, or an empty string ("") if no conflicts
+#           occured.
+# :rtype: (bool, desc)
+#
+# Error Checking
+# ==============
+#
+# If CMakePP is run in debug mode (and only if it is run in debug mode) this
+# function will assert that it was called with all three arguments and that
+# the arguments have the correct types.
+#
+# :var CMAKEPP_LANG_DEBUG_MODE: Used to determine if CMakePP is being run in
+#                               debug mode or not.
+# :vartype CMAKEPP_LANG_DEBUG_MODE: bool
+#]]
+function(cpp_check_conflicts _cc_conflict _cc_conflicting_type _cc_name)
+    cpp_assert_signature("${ARGV}" desc desc desc)
+
+    # This is a list of all of the "built-in" types for CMakePPLang
+    set(
+        _cc_cpp_types
+        bool fxn path float genexpr int list str target desc type class map obj
+    )
+
+    # Check if each type matches the given type, which results in a conflict
+    foreach(_cc_cpp_type ${_cc_cpp_types})
+        if("${_cc_cpp_type}" STREQUAL "${_cc_name}")
+            set("${_cc_conflict}" TRUE PARENT_SCOPE)
+            set("${_cc_conflicting_type}" "${_cc_cpp_type}" PARENT_SCOPE)
+            return()
+        endif()
+    endforeach()
+
+    # No conflict was found
+    set("${_cc_conflict}" FALSE PARENT_SCOPE)
+    set("${_cc_conflicting_type}" "" PARENT_SCOPE)
+endfunction()

--- a/tests/class/class.cmake
+++ b/tests/class/class.cmake
@@ -30,6 +30,11 @@ function(${_test_class})
         endfunction()
     endfunction()
 
+    ct_add_section(NAME "_class_conflict_w_built_in" EXPECTFAIL)
+    function(${_class_conflict_w_built_in})
+        cpp_class(Target)
+    endfunction()
+
     ct_add_section(NAME "_class_base")
     function(${_class_base})
         cpp_class(BaseClass)


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
There is currently no checking for whether user-defined class names conflict with either built-in data types of CMakePPLang or other function signatures that may be defined in CMakePPLang or CMake. This PR solves part of the issue by checking user-defined class names against a list of built-in data type identifiers defined by CMakePPLang.

**TODOs**
- [ ] Document usage of the `cpp_check_conflicts()` utility function in the user documentation if this work looks good.
- [ ] Write individual tests for `cpp_check_conflicts()` if this work looks good.
