### PR TITLE
Add ability to manually trigger the doc generation CI

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -18,6 +18,9 @@ on:
   pull_request:
     types:
       - closed
+      
+  # Allows manual triggering with the "Run workflow" button
+  workflow_dispatch:
 
 jobs:
   Build-Documentation:


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
It is much easier to re-trigger CI for testing as needed if it is able to be manually triggered at any time. I added that ability to the documentation generation CI.
