### PR TITLE
Specify module for CMinx API documentation

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -27,6 +27,8 @@ jobs:
     if: github.event.pull_request.merged == true
     uses: CMakePP/.github/.github/workflows/deploy_docs_master.yaml@main
     with:
+      api_docs_module: 'cmakepp_lang'
+      docs_dir: 'docs'
       python_version: '3.10'
       docs_dir: 'docs'
     secrets:


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
Fixes #39.

**Description**
Based on the updates from CMakePP org .github [PR 18](https://github.com/CMakePP/.github/pull/18), CMinx API documentation can be generated if an `api_docs_module` name is provided. In this case, that will be `cmakepp_lang`. This should generate the API documentation when the `deploy_docs` action is performed.
