### PR TITLE
Fix badges in top-level README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,9 +17,11 @@
 CMakePPLang
 ###########
 
-![CMakePPLang Unit Tests](https://github.com/CMakePP/CMakePPLang/workflows/CMakePPLang%20Unit%20Tests/badge.svg)
+.. image:: https://github.com/CMakePP/CMakePPLang/workflows/CMakePPLang%20Unit%20Tests/badge.svg
+   :target: https://github.com/CMakePP/CMakePPLang/workflows/CMakePPLang%20Unit%20Tests/badge.svg
 
-[![Documentation](https://github.com/CMakePP/CMakePPLang/actions/workflows/deploy_docs.yml/badge.svg?branch=master)](https://github.com/CMakePP/CMakePPLang/actions/workflows/deploy_docs.yml)
+.. image:: https://github.com/CMakePP/CMakePPLang/actions/workflows/deploy_docs.yml/badge.svg?branch=master
+   :target: https://github.com/CMakePP/CMakePPLang/actions/workflows/deploy_docs.yml/badge.svg?branch=master
 
 *****************
 Statement of Need


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
The badges for unit tests and documentation status are currently not in the correct format. This should fix them.
