### PR TITLE
Fix bug in documentation CI

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -30,6 +30,5 @@ jobs:
       api_docs_module: 'cmakepp_lang'
       docs_dir: 'docs'
       python_version: '3.10'
-      docs_dir: 'docs'
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
There were two definitions of `docs_dir`. This causes an error in the CI. This PR removes the second definition.
