### PR TITLE
Automatically add license headers to files

### DIFF
--- a/.github/.licenserc.yaml
+++ b/.github/.licenserc.yaml
@@ -1,0 +1,32 @@
+# Copyright 2021 CMakePP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+header:
+  license:
+    spdx-id: Apache-2.0
+    copyright-owner: CMakePP
+
+  paths-ignore:
+    - .github/
+    - .gitignore
+    - docs/source/developer/*.drawio
+    - docs/source/developer/*.png
+    - docs/source/developer/uml_diagrams/*.drawio
+    - docs/Makefile
+    - docs/requirements.txt
+    - examples/
+    - tests/
+    - LICENSE
+
+  comment: never

--- a/.github/workflows/add_licenses.yml
+++ b/.github/workflows/add_licenses.yml
@@ -1,0 +1,28 @@
+# Copyright 2021 CMakePP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+name: Add Licenses
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  license_files:
+    uses: CMakePP/.github/.github/workflows/add_licenses_master.yaml@main
+    with:
+      config_file: .github/.licenserc.yaml
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
Closes #73.

**Description**
Creates a CI action to add license header to all files not ignored in `.github/.licenserc.yaml`. This is based almost exactly on the process used by CMinx ([link](https://github.com/CMakePP/CMinx/blob/master/.github/workflows/add_licenses.yaml)).