### PR TITLE
Fix path to generated API documentation

### DIFF
--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -5,4 +5,4 @@ API
 .. toctree::
    :maxdepth: 2
 
-   generated_docs/index
+   generated_docs/cmakepp_lang/index


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
The generated API documentation was being output to the incorrect location. This was fixed in CMakePP/.github [PR 19](https://github.com/CMakePP/.github/pull/19), so the TOC file here needs to be updated as well to agree with this updated location.