### PR TITLE
Refactoring for Consistency

### DIFF
--- a/cmake/cmakepp_lang/asserts/assert.cmake
+++ b/cmake/cmakepp_lang/asserts/assert.cmake
@@ -38,7 +38,7 @@ include_guard()
 #
 # .. code-block:: cmake
 #
-#    include(cmakepp_lang/utilities/assert)
+#    include(cmakepp_lang/asserts/assert)
 #    include(cmakepp_lang/types/integer)
 #    cpp_is_int(is_int 3)
 #    cpp_assert("${_is_int}" "3 is an integer")
@@ -48,7 +48,7 @@ include_guard()
 #
 # .. code-block:: cmake
 #
-#    include(cmakepp_lang/utilities/assert)
+#    include(cmakepp_lang/asserts/assert)
 #    set(x 4)
 #    cpp_assert("${x};GREATER;3" "x is > 3")
 #]]

--- a/cmake/cmakepp_lang/asserts/asserts.cmake
+++ b/cmake/cmakepp_lang/asserts/asserts.cmake
@@ -14,5 +14,6 @@
 
 include_guard()
 
+include(cmakepp_lang/asserts/assert)
 include(cmakepp_lang/asserts/signature)
 include(cmakepp_lang/asserts/type)

--- a/cmake/cmakepp_lang/asserts/signature.cmake
+++ b/cmake/cmakepp_lang/asserts/signature.cmake
@@ -14,7 +14,7 @@
 
 include_guard()
 include(cmakepp_lang/asserts/type)
-include(cmakepp_lang/utilities/assert)
+include(cmakepp_lang/asserts/assert)
 include(cmakepp_lang/utilities/enable_if_debug)
 
 #[[[

--- a/cmake/cmakepp_lang/asserts/type.cmake
+++ b/cmake/cmakepp_lang/asserts/type.cmake
@@ -15,7 +15,7 @@
 include_guard()
 include(cmakepp_lang/types/implicitly_convertible)
 include(cmakepp_lang/types/type_of)
-include(cmakepp_lang/utilities/assert)
+include(cmakepp_lang/asserts/assert)
 include(cmakepp_lang/utilities/enable_if_debug)
 
 #[[[

--- a/cmake/cmakepp_lang/map/append.cmake
+++ b/cmake/cmakepp_lang/map/append.cmake
@@ -1,0 +1,52 @@
+# Copyright 2023 CMakePP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include_guard()
+
+include(cmakepp_lang/asserts/signature)
+include(cmakepp_lang/utilities/global)
+
+#[[[
+# Appends to the value stored under the specified key.
+#
+# This member function will append the provided value to the list stored under
+# the specified key. If the key does not exist, a list will be started with the
+# provided value and stored under the specified key.
+#
+# :param this: The map we modifying the state of.
+# :type this: map
+# :param key: The key whose value is being appended to.
+# :type key: str
+# :param value: Value we are appending to the list stored under ``_ma_key``.
+# :type value: str
+#
+# Error Checking
+# ==============
+#
+# If CMakePP is run in debug mode, this function will assert that it is called
+# with the correct number of arguments and that each argument has the correct
+# type. If an assert fails an error will be raised. The assertions happen only
+# when CMakePP is run in debug mode.
+#
+# :var CMAKEPP_LANG_DEBUG_MODE: Used to determine if CMakePP is being run in
+#                               debug mode or not.
+# :vartype CMAKEPP_LANG_DEBUG_MODE: bool
+#
+#]]
+function(cpp_map_append _ma_this _ma_key _ma_value)
+    cpp_assert_signature("${ARGV}" map str str)
+
+    cpp_append_global("${_ma_this}_keys" "${_ma_key}")
+    cpp_append_global("${_ma_this}_keys_${_ma_key}" "${_ma_value}")
+endfunction()

--- a/cmake/cmakepp_lang/map/ctor.cmake
+++ b/cmake/cmakepp_lang/map/ctor.cmake
@@ -1,0 +1,64 @@
+# Copyright 2023 CMakePP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include_guard()
+
+include(cmakepp_lang/asserts/signature)
+include(cmakepp_lang/utilities/global)
+include(cmakepp_lang/utilities/return)
+include(cmakepp_lang/utilities/unique_id)
+
+#[[[
+# Constructs a new Map instance with the specified state (if provided)
+#
+# This function creates a new Map instance. The caller may provided one or more
+# pairs of input to be used as the initial state. If provided, the pairs are
+# assumed to be such that the first value is the key and the second value is the
+# value to associate with that key. If no key-value pairs are provided the
+# resulting map will be empty.
+#
+# :param result: Name for variable which will hold the new map.
+# :type result: desc
+# :param \*args: A list whose elements will be considered pairwise to be the
+#               initial key-value pairs populating the map.
+# :returns: ``_mc_result`` will be set to the newly created Map instance.
+# :rtype: map
+#
+# Error Checking
+# ==============
+#
+# If CMakePP is run in debug mode this function will assert that it has been
+# called with at least one argument, that this argument is of type ``desc``,
+# and that any additional arguments are of type ``(desc, str)``. If any of these
+# assertions fail an error will be raised. These assertions are only performed
+# if CMakePP is run in debug mode.
+#
+# :var CMAKEPP_LANG_DEBUG_MODE: Used to determine if CMakePP is being run in
+#                               debug mode.
+# :vartype CMAKEPP_LANG_DEBUG_MODE: bool
+#]]
+function(cpp_map_ctor _mc_result)
+    cpp_assert_signature("${ARGV}" desc args)
+
+    # "Allocate" the new instance and set its type
+    cpp_unique_id("${_mc_result}")
+    cpp_set_global("${${_mc_result}}__type" map)
+
+    # If variadic, the additional arguments are the initial state so call "set"
+    if("${ARGC}" GREATER 1)
+        cpp_map_set("${${_mc_result}}" ${ARGN})
+    endif()
+
+    cpp_return("${_mc_result}")
+endfunction()

--- a/cmake/cmakepp_lang/map/get_set.cmake
+++ b/cmake/cmakepp_lang/map/get_set.cmake
@@ -1,0 +1,98 @@
+# Copyright 2023 CMakePP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#[[[ @module
+# Defines functions to get and set key/value pairs for a CMakePPLang Map.
+#]]
+
+include_guard()
+
+include(cmakepp_lang/asserts/signature)
+include(cmakepp_lang/utilities/global)
+include(cmakepp_lang/utilities/return)
+
+#[[[
+# Retrieves the value of the specified key.
+#
+# This function is used to retrieve the value associated with the provided key.
+# If a key has not been set this function will return the empty string. Users
+# can use ``cpp_map_has_key`` to determine whether the map does not have the
+# key or if the key was simply set to the empty string.
+#
+# :param this: The map storing the key-value pairs.
+# :type this: map
+# :param value: Name for the identifier to save the value to.
+# :type value: desc
+# :param key: The key whose value we want.
+# :type key: str
+# :returns: ``_mg_value`` will be set to the value associated with ``_mg_key``.
+#           If ``_mg_key`` has no value associated with it ``_mg_value`` will be
+#           set to the empty string.
+# :rtype: str
+#
+# Error Checking
+# ==============
+#
+# If CMakePP is run in debug mode this function will ensure that it has been
+# provided exactly three arguments and that those arguments are of the correct
+# types. If any of these checks fail an error will be raised. These checks are
+# only performed if CMakePP is being run in debug mode.
+#
+# :var CMAKEPP_LANG_DEBUG_MODE: Used to determine if CMakePP is being run in
+#                               debug mode.
+# :vartype CMAKEPP_LANG_DEBUG_MODE: bool
+#]]
+function(cpp_map_get _mg_this _mg_value _mg_key)
+    cpp_assert_signature("${ARGV}" map desc str)
+
+    cpp_get_global("${_mg_value}" "${_mg_this}_keys_${_mg_key}")
+    cpp_return("${_mg_value}")
+endfunction()
+
+#[[[
+# Associates a value with the specified key.
+#
+# This function can be used to set the value of a map's key. If the key has a
+# value associated with it already that value will be overridden.
+#
+# :param this: The map whose key is going to be set.
+# :type this: map
+# :param key: The key whose value is going to be set.
+# :type key: str
+# :param value: The value to set the key to.
+# :type value: str
+#
+# Error Checking
+# ==============
+#
+# If CMakePP is run in debug mode this function will assert that it was called
+# with exactly three arguments, and that those arguments have the correct types.
+# If these assertions fail an error will be raised. These checks are only
+# performed if CMakePP is run in debug mode.
+#
+# :var CMAKEPP_LANG_DEBUG_MODE: Used to determine if CMakePP is being run in
+#                               debug mode or not.
+# :vartype CMAKEPP_LANG_DEBUG_MODE: bool
+#
+#]]
+function(cpp_map_set _ms_this _ms_key _ms_value)
+    cpp_assert_signature("${ARGV}" map str str args)
+
+    cpp_append_global("${_ms_this}_keys" "${_ms_key}")
+    cpp_set_global("${_ms_this}_keys_${_ms_key}" "${_ms_value}")
+
+    if("${ARGC}" GREATER 3)
+        cpp_map_set("${_ms_this}" ${ARGN})
+    endif()
+endfunction()

--- a/cmake/cmakepp_lang/map/map.cmake
+++ b/cmake/cmakepp_lang/map/map.cmake
@@ -14,8 +14,11 @@
 
 include_guard()
 include(cmakepp_lang/asserts/signature)
+include(cmakepp_lang/map/append)
 include(cmakepp_lang/map/copy)
+include(cmakepp_lang/map/ctor)
 include(cmakepp_lang/map/equal)
+include(cmakepp_lang/map/get_set)
 include(cmakepp_lang/map/has_key)
 include(cmakepp_lang/map/keys)
 include(cmakepp_lang/map/merge)
@@ -25,161 +28,7 @@ include(cmakepp_lang/utilities/return)
 include(cmakepp_lang/utilities/unique_id)
 
 #[[[
-# Appends to the value stored under the specified key.
-#
-# This member function will append the provided value to the list stored under
-# the specified key. If the key does not exist, a list will be started with the
-# provided value and stored under the specified key.
-#
-# :param this: The map we modifying the state of.
-# :type this: map
-# :param key: The key whose value is being appended to.
-# :type key: str
-# :param value: Value we are appending to the list stored under ``_ma_key``.
-# :type value: str
-#
-# Error Checking
-# ==============
-#
-# If CMakePP is run in debug mode, this function will assert that it is called
-# with the correct number of arguments and that each argument has the correct
-# type. If an assert fails an error will be raised. The assertions happen only
-# when CMakePP is run in debug mode.
-#
-# :var CMAKEPP_LANG_DEBUG_MODE: Used to determine if CMakePP is being run in
-#                               debug mode or not.
-# :vartype CMAKEPP_LANG_DEBUG_MODE: bool
-#
-#]]
-function(cpp_map_append _ma_this _ma_key _ma_value)
-    cpp_assert_signature("${ARGV}" map str str)
-
-    cpp_append_global("${_ma_this}_keys" "${_ma_key}")
-    cpp_append_global("${_ma_this}_keys_${_ma_key}" "${_ma_value}")
-endfunction()
-
-#[[[
-# Constructs a new Map instance with the specified state (if provided)
-#
-# This function creates a new Map instance. The caller may provided one or more
-# pairs of input to be used as the initial state. If provided, the pairs are
-# assumed to be such that the first value is the key and the second value is the
-# value to associate with that key. If no key-value pairs are provided the
-# resulting map will be empty.
-#
-# :param result: Name for variable which will hold the new map.
-# :type result: desc
-# :param \*args: A list whose elements will be considered pairwise to be the
-#               initial key-value pairs populating the map.
-# :returns: ``_mc_result`` will be set to the newly created Map instance.
-# :rtype: map
-#
-# Error Checking
-# ==============
-#
-# If CMakePP is run in debug mode this function will assert that it has been
-# called with at least one argument, that this argument is of type ``desc``,
-# and that any additional arguments are of type ``(desc, str)``. If any of these
-# assertions fail an error will be raised. These assertions are only performed
-# if CMakePP is run in debug mode.
-#
-# :var CMAKEPP_LANG_DEBUG_MODE: Used to determine if CMakePP is being run in
-#                               debug mode.
-# :vartype CMAKEPP_LANG_DEBUG_MODE: bool
-#]]
-function(cpp_map_ctor _mc_result)
-    cpp_assert_signature("${ARGV}" desc args)
-
-    # "Allocate" the new instance and set its type
-    cpp_unique_id("${_mc_result}")
-    cpp_set_global("${${_mc_result}}__type" map)
-
-    # If variadic, the additional arguments are the initial state so call "set"
-    if("${ARGC}" GREATER 1)
-        cpp_map_set("${${_mc_result}}" ${ARGN})
-    endif()
-
-    cpp_return("${_mc_result}")
-endfunction()
-
-#[[[
-# Retrieves the value of the specified key.
-#
-# This function is used to retrieve the value associated with the provided key.
-# If a key has not been set this function will return the empty string. Users
-# can use ``cpp_map_has_key`` to determine whether the map does not have the
-# key or if the key was simply set to the empty string.
-#
-# :param this: The map storing the key-value pairs.
-# :type this: map
-# :param value: Name for the identifier to save the value to.
-# :type value: desc
-# :param key: The key whose value we want.
-# :type key: str
-# :returns: ``_mg_value`` will be set to the value associated with ``_mg_key``.
-#           If ``_mg_key`` has no value associated with it ``_mg_value`` will be
-#           set to the empty string.
-# :rtype: str
-#
-# Error Checking
-# ==============
-#
-# If CMakePP is run in debug mode this function will ensure that it has been
-# provided exactly three arguments and that those arguments are of the correct
-# types. If any of these checks fail an error will be raised. These checks are
-# only performed if CMakePP is being run in debug mode.
-#
-# :var CMAKEPP_LANG_DEBUG_MODE: Used to determine if CMakePP is being run in
-#                               debug mode.
-# :vartype CMAKEPP_LANG_DEBUG_MODE: bool
-#]]
-function(cpp_map_get _mg_this _mg_value _mg_key)
-    cpp_assert_signature("${ARGV}" map desc str)
-
-    cpp_get_global("${_mg_value}" "${_mg_this}_keys_${_mg_key}")
-    cpp_return("${_mg_value}")
-endfunction()
-
-#[[[
-# Associates a value with the specified key.
-#
-# This function can be used to set the value of a map's key. If the key has a
-# value associated with it already that value will be overridden.
-#
-# :param this: The map whose key is going to be set.
-# :type this: map
-# :param key: The key whose value is going to be set.
-# :type key: str
-# :param value: The value to set the key to.
-# :type value: str
-#
-# Error Checking
-# ==============
-#
-# If CMakePP is run in debug mode this function will assert that it was called
-# with exactly three arguments, and that those arguments have the correct types.
-# If these assertions fail an error will be raised. These checks are only
-# performed if CMakePP is run in debug mode.
-#
-# :var CMAKEPP_LANG_DEBUG_MODE: Used to determine if CMakePP is being run in
-#                               debug mode or not.
-# :vartype CMAKEPP_LANG_DEBUG_MODE: bool
-#
-#]]
-function(cpp_map_set _ms_this _ms_key _ms_value)
-    cpp_assert_signature("${ARGV}" map str str args)
-
-    cpp_append_global("${_ms_this}_keys" "${_ms_key}")
-    cpp_set_global("${_ms_this}_keys_${_ms_key}" "${_ms_value}")
-
-    if("${ARGC}" GREATER 3)
-        cpp_map_set("${_ms_this}" ${ARGN})
-    endif()
-endfunction()
-
-#[[[
 # Public API for interacting with Map instances.
-#
 #
 # :param mode: The name of the member function to call.
 # :type mode: desc

--- a/cmake/cmakepp_lang/utilities/utilities.cmake
+++ b/cmake/cmakepp_lang/utilities/utilities.cmake
@@ -14,7 +14,7 @@
 
 include_guard()
 
-include(cmakepp_lang/utilities/assert)
+include(cmakepp_lang/asserts/assert)
 include(cmakepp_lang/utilities/call_fxn)
 include(cmakepp_lang/utilities/compare_lists)
 include(cmakepp_lang/utilities/directory_exists)

--- a/tests/asserts/assert.cmake
+++ b/tests/asserts/assert.cmake
@@ -10,7 +10,7 @@ include(cmake_test/cmake_test)
 
 ct_add_test(NAME "test_cpp_assert")
 function("${test_cpp_assert}")
-    include(cmakepp_lang/utilities/assert)
+    include(cmakepp_lang/asserts/assert)
 
     ct_add_section(NAME "true_value")
     function("${true_value}")


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
This PR does some miscellaneous refactoring to make the codebase more consistent.

**TODOs**
- [ ] Make files named the same as their subdirectory (like `map/map.cmake`) primarily include other files containing public API functions instead of containing the public API code itself.
- [x] Move `utilities/assert.cmake` to `asserts/assert.cmake`.
