### PR TITLE
Add license headers from joss_paper branch

### DIFF
--- a/docs/source/authors.rst
+++ b/docs/source/authors.rst
@@ -1,1 +1,15 @@
+.. Copyright 2023 CMakePP
+..
+.. Licensed under the Apache License, Version 2.0 (the "License");
+.. you may not use this file except in compliance with the License.
+.. You may obtain a copy of the License at
+..
+.. http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing, software
+.. distributed under the License is distributed on an "AS IS" BASIS,
+.. WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+.. See the License for the specific language governing permissions and
+.. limitations under the License.
+
 .. include:: ../../AUTHORS.rst

--- a/docs/source/license.rst
+++ b/docs/source/license.rst
@@ -1,3 +1,17 @@
+.. Copyright 2023 CMakePP
+..
+.. Licensed under the Apache License, Version 2.0 (the "License");
+.. you may not use this file except in compliance with the License.
+.. You may obtain a copy of the License at
+..
+.. http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing, software
+.. distributed under the License is distributed on an "AS IS" BASIS,
+.. WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+.. See the License for the specific language governing permissions and
+.. limitations under the License.
+
 .. _license:
 
 =======


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
This PR moves the license headers from the `joss_paper` branch to clean it up.