### PR TITLE
Update Code of Conduct link

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -50,7 +50,7 @@ debugging code written in CMakePPLang, as well as notes for developers.
    api/index
    debugging
    developer/index
-   Contributing <https://cmakepp.github.io/.github/code_of_conduct/index.html>
+   Contributing <https://cmakepp.github.io/.github/code_of_conduct.html>
    Authors <authors>
    license
 


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
Fixes #93.

**Description**
This PR updates the "Contributing" link on the documentation main page to have the correct URL pointing to the CMakePP Organization's Code of Conduct.
