### PR TITLE
Update Contributing Guidelines Link in README.md

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -124,7 +124,7 @@ recommend you start a draft PR early in the process so we know the contribution
 is coming and can help you along the way.
 
 CMakePPLang is part of the CMakePP organization, whose contributing guidelines
-can be found `here <https://github.com/CMakePP/.github/blob/main/CONTRIBUTING.md>`__.
+can be found `here <https://cmakepp.github.io/.github/code_of_conduct.html>`__.
 
 Developer documentation can be found
 `here <https://cmakepp.github.io/CMakePPLang/developer/index.html>`__ to help


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
Related to #93.

**Description**
The link in the README.md for the CMakePP organization contributing guidelines was incorrect. This PR fixes it.
