### PR TITLE
Update detailed installation instructions link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ CMakePPLang can be included in a CMake project by adding:
 
 to your ``CMakeLists.txt`` file. CMakePPLang will then be downloaded as part
 of the CMake configuration step. More detailed instructions, can be found
-`here <https://cmakepp.github.io/CMakePPLang/getting_started/obtaining_cmakepplanglanglang.html>`__.
+`here <https://cmakepp.github.io/CMakePPLang/getting_started/obtaining_cmakepplang.html>`__.
 
 *************
 Example Usage


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
Fixes #101.

**Description**
Changes detailed installation link from https://cmakepp.github.io/CMakePPLang/getting_started/obtaining_cmakepplanglanglang.html to https://cmakepp.github.io/CMakePPLang/getting_started/obtaining_cmakepplang.html.