### PR TITLE
Update full API documentation link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -111,7 +111,7 @@ API Documentation
 *****************
 
 Full API documentation can be found
-`here <https://cmakepp.github.io/CMakePPLang/api/index.html>`__.
+`here <https://cmakepp.github.io/CMakePPLang/developer/index.html#cmakepplang-api>`__.
 
 ************
 Contributing


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
Fixes #103.

**Description**
Updates the full documentation link in README.md from https://cmakepp.github.io/CMakePPLang/api/index.html to https://cmakepp.github.io/CMakePPLang/developer/index.html#cmakepplang-api.
