### PR TITLE
addresses comments from tianyi93

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,19 +23,45 @@ CMakePPLang
 .. image:: https://github.com/CMakePP/CMakePPLang/actions/workflows/deploy_docs.yml/badge.svg?branch=master
    :target: https://github.com/CMakePP/CMakePPLang/actions/workflows/deploy_docs.yml/badge.svg?branch=master
 
+CMakePPLang defines the basic extensions of the CMake language which comprise
+the CMakePP language. Think of this repo as being like the standard C++ library,
+except for CMake.
+
 *****************
 Statement of Need
 *****************
 
-CMakePPLang defines the basic extensions of the CMake language which comprise
-the CMakePP language. Think of this repo as being like the standard C++ library,
-except for CMake.
+CMake is arguably the *de facto* build tool for building C and C++ software
+packages of moderate to large size. Anecdotally we have observed that, as the
+size of a package grows, so too does the complexity of its build system.
+Object-oriented programming (OOP) is a popular and established technique for
+managing complexity in software and we assert that OOP can also be used to
+manage the complexity of the build system. Unfortunately, CMake is a functional
+language with no OOP support. Given the ubiquitous nature of CMake-based build
+systems and tools, the ideal OOP solution is to introduce OOP into CMake via a
+mechanism which preserves backwards compatibility with standard CMake.
+
+We are not the first to suggest such a solution. To that end, Tobias Becker
+created the [CMake++](https://github.com/toeb/cmakepp) (formally called
+cmake-oo) module, which contains a number of CMake extensions including support
+for OOP. As of this writing, CMake++ seems to be an abandoned project with only
+two commits since July of 2017, both in 2021. As far as we know there are no
+other OOP CMake solutions out there.
+
+Before creating CMakePPLang, we considered whether or not to attempt to
+resurrect CMake++. Looking through the CMake++ repo we were able to find a
+decent amount of user documentation, but little to no API or developer
+documentation. Ultimately, we decided that the effort needed to understand
+CMake++, document it with [CMinx](https://github.com/CMakePP/CMinx), and test
+it with [CMakeTest](https://github.com/CMakePP/CMakeTest) would be greater than
+writing a new, ground-up, OOP extension to CMake, and CMakePPLang was born.
 
 *************************
 Installation Instructions
 *************************
 
-CMakePPLang can be included in a CMake project by adding:
+CMakePPLang is distributed as a CMake module and can thus be included in CMake
+projects simply by adding:
 
 .. code-block:: cmake
 
@@ -48,8 +74,13 @@ CMakePPLang can be included in a CMake project by adding:
    FetchContent_MakeAvailable(cmakepp_lang)
 
 to your ``CMakeLists.txt`` file. CMakePPLang will then be downloaded as part
-of the CMake configuration step. More detailed instructions, can be found
+of your project's CMake configuration step. More detailed instructions, can be
+found
 `here <https://cmakepp.github.io/CMakePPLang/getting_started/obtaining_cmakepplang.html>`__.
+
+If you would like to independently verify CMakePPLang works please see the
+instructions for running the test suite located in the developer documentation
+(`link <https://cmakepp.github.io/CMakePPLang/developer/initial_setup.html>`__).
 
 *************
 Example Usage


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
Please list issues associated with this pull request, including [closing words](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
as appropriate.

https://github.com/openjournals/joss-reviews/issues/5711

**Description**

Reviewer @tianyi93 raised two concerns with CMakePPLang:

1. The "Statement of Need" section in the README was not as comprehensive as that in the paper. And
2. There were no instructions for how to run the test suite.

This PR addresses 1 by adding to the "Statement of Need" section a reference to CMake++ and a brief discussion of why we felt it was not sufficient. We did not verbatim copy the JOSS paper's statement of need, but feel that the added verbiage captures the sentiment of the full statement of need found in the JOSS paper. Once the JOSS paper is published we intend to link to it so interested users can read more.

With regards to 2, CMakePPLang is designed to be used as a CMake module so we anticipate that most users will simply include CMakePPLang in their project, and then use it (no testing step). We anticipate that testing of CMakePPLang will primarily be done by CI/CD and CMakePPLang developers, both of whom are expected to follow the developer workflow, not the user workflow. While the [developer workflow instructions](https://cmakepp.github.io/CMakePPLang/developer/initial_setup.html) do state how a developer can test CMakePPLang, these instructions were admittedly quite buried in the documentation. So to address 2 I have added to the "Installation Instructions" section of the README, a direct link to these instructions. 

**TODOs**

@tianyi93 please let us know if these changes sufficiently address your concerns, and if they do not, how we can improve them.
