### PR TITLE
pin CMakeTest version

### DIFF
--- a/docs/source/versioning.rst
+++ b/docs/source/versioning.rst
@@ -1,3 +1,17 @@
+.. Copyright 2023 CMakePP
+..
+.. Licensed under the Apache License, Version 2.0 (the "License");
+.. you may not use this file except in compliance with the License.
+.. You may obtain a copy of the License at
+..
+.. http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing, software
+.. distributed under the License is distributed on an "AS IS" BASIS,
+.. WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+.. See the License for the specific language governing permissions and
+.. limitations under the License.
+
 ******************
 Release Versioning
 ******************

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ include(cmaize/cmaize)
 FetchContent_Declare(
     cmake_test
     GIT_REPOSITORY https://github.com/CMakePP/CMakeTest
+    GIT_TAG 99901a11adda1b21abed7941c10641b2b03c11ad
 )
 set(build_testing_old "${BUILD_TESTING}")
 set(BUILD_TESTING OFF CACHE BOOL "" FORCE)


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**


**Description**
Unit tests are currently failing because of an update in CMakeTest. This PR pins the version of CMakeTest to avoid this issue.

**TODOs**
None. 
