### PR TITLE
Fix Multi Append

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,12 @@ project(CMakePPLang VERSION 1.0.0 LANGUAGES NONE)
 option(BUILD_TESTING "Should we build and run the unit tests?" OFF)
 
 # Adds CMakePPLang to the module path so it can be included as
-# include(cmakepp_lang/cmakepp_lang)
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+# include(cmakepp_lang/cmakepp_lang), checks to make sure it hasn't been added
+# before.
+list(FIND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}" path_has_cmake)
+if(${path_has_cmake} STREQUAL "-1")
+    list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+endif()
 set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" CACHE STRING "" FORCE)
 
 if(NOT CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
When CMakePPLang is included in another project via `FetchContent`, if that project imports `CMakePPLang` and then gets reconfigured, CMakePPLang will continuously append its location to the calling project's `CMAKE_MODULE_PATH`. This PR checks to make sure the path is not present in `CMAKE_MODULE_PATH` before adding it.

**TODOs**
None. This is r2g.
