### PR TITLE
Fix incorrect flatten_args with default vals, fix duplicated test section names

### DIFF
--- a/cmake/cmakepp_lang/class/flatten_attrs.cmake
+++ b/cmake/cmakepp_lang/class/flatten_attrs.cmake
@@ -65,15 +65,17 @@ function(_cpp_flatten_attrs _fa_this)
         # them from the subobj
         list(LENGTH _fa_subobj_attr_keys _fa_subobj_attr_keys_len)
         if(_fa_subobj_attr_keys_len GREATER 0)
-            _cpp_object_get_attr("${_fa_subobj_i}" "_r_attr" ${_fa_subobj_attr_keys})
 
             # Loop over each attribute
-            foreach(_fa_attr_key_i ${_fa_subobj_attr_keys})
+            foreach(_fa_attr_key_i IN LISTS _fa_subobj_attr_keys)
                 # If this doesn't already have this attr, add it
                 cpp_map(HAS_KEY "${_fa_this_attrs}" _fa_this_has_key "${_fa_attr_key_i}")
                 if(NOT "${_fa_this_has_key}")
+                    # Grab the default value, if any, and add
+                    # the attribute along with its default to _fa_this
+                    cpp_map(GET "${_fa_subobj_attrs}" _fa_subobj_attr_i "${_fa_attr_key_i}")
                     _cpp_object_set_attr("${_fa_this}" "${_fa_attr_key_i}"
-                                         "${_r_attr_${_fa_attr_key_i}}")
+                                         "${_fa_subobj_attr_i}")
                 endif()
 
                 # Remove the attribute from the subobjs attributes

--- a/cmake/cmakepp_lang/object/attrs.cmake
+++ b/cmake/cmakepp_lang/object/attrs.cmake
@@ -72,7 +72,7 @@ function(_cpp_object_get_attr_guts _ogag_this _ogag_value _ogag_done _ogag_attr)
     # This part of the object did not have the attribute, so loop over bases
     _cpp_object_get_meta_attr("${_ogag_this}" _ogag_sub_objs "sub_objs")
     cpp_map(KEYS "${_ogag_sub_objs}" _ogag_bases)
-    foreach(_ogag_type_i ${_ogag_bases})
+    foreach(_ogag_type_i IN LISTS _ogag_bases)
 
         # Get the i-th base class and see if it has the attribute
         cpp_map(GET "${_ogag_sub_objs}" _ogag_base_i "${_ogag_type_i}")

--- a/tests/docs/source/getting_started/cmakepp_examples/classes/multiple_inheritance_basics.cmake
+++ b/tests/docs/source/getting_started/cmakepp_examples/classes/multiple_inheritance_basics.cmake
@@ -57,7 +57,7 @@ function("${CMAKETEST_TEST}")
         ct_assert_equal(result2 "3500")
     endfunction()
 
-    ct_add_section(NAME [[parent_attribute_access]])
+    ct_add_section(NAME [[parent_method_access]])
     function("${CMAKETEST_SECTION}")
         # Create instance of the subclass
         ElectricTruck(CTOR my_inst)

--- a/tests/utilities/check_conflicting_types.cmake
+++ b/tests/utilities/check_conflicting_types.cmake
@@ -45,7 +45,7 @@ function("${CMAKETEST_TEST}")
     ct_add_section(NAME [[test_no_conflicts]])
     function("${CMAKETEST_SECTION}")
 
-        ct_add_section(NAME [[test_capitalization]])
+        ct_add_section(NAME [[test_underscores]])
         function("${CMAKETEST_SECTION}")
 
             cpp_check_conflicting_types(


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
Fixes #129 and #128 

**Description**
This PR fixes two duplicated test section names discovered by https://github.com/CMakePP/CMakeTest/pull/94
In doing so, however, a bug was revealed where inherited attributes did not have their default values.  This PR also fixes that issue.

**Side note**
There appears to be code in `_cpp_object_get_attr_guts` that assumes non-flattened attributes and that only the attributes defined in the class itself would be stored in the `attrs` meta-attribute. Is there a particular reason flattening the arguments was needed?

