### PR TITLE
Pin sphinx to less than 7.2.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
+sphinx<7.2.0
 sphinx_rtd_theme
 cminx>=1.1.7


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
Fixes #131 

**Description**
Pins Sphinx to versions less than 7.2.0. See https://github.com/CMakePP/CMakeTest/pull/96 for similar patch and details

