### PR TITLE
Updates cpp_contains to work with arbitrary types

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -8,13 +8,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        cmake: [3.14.7, latest, latestrc]
+        cmake: [3.19, latest, latestrc]
     env:
       cmake_version: ${{ matrix.cmake }}
       os: Linux-x86_64
     steps:
       - uses: actions/checkout@v1
-      
+
 #       - name: get cmake
 #         env:
 #           url_prefix: https://github.com/Kitware/CMake/releases/download
@@ -27,16 +27,16 @@ jobs:
         uses: lukka/get-cmake@latest
         with:
           cmakeVersion: ${{ env.cmake_version }}
-          
+
       - name: Check CMake and CTest Versions
         run: |
           cmake --version
           ctest --version
-          
+
       - name: configure
         run: |
           cmake -H. -Bbuild -DBUILD_TESTING=ON
-          
+
       - name: unit_test
         run: |
           cd build

--- a/cmake/cmakepp_lang/algorithm/contains.cmake
+++ b/cmake/cmakepp_lang/algorithm/contains.cmake
@@ -63,28 +63,26 @@ include(cmakepp_lang/utilities/return)
 # with the correct number of arguments and that those arguments have the correct
 # types. These error checks are only performed if CMakePP is run in debug mode.
 #
-# :raises BAD_LIST_TYPE: If ``list`` is not recognized as a desc, list, or map.
-#
 #]]
 function(cpp_contains _c_result _c_item _c_list)
     cpp_assert_signature("${ARGV}" desc str str)
 
     cpp_type_of(_c_list_type "${_c_list}")
-    set("${_c_result}" FALSE PARENT_SCOPE)
 
-    if("${_c_list_type}" STREQUAL "list")
-        if("${_c_item}" IN_LIST _c_list)
-            set("${_c_result}" TRUE PARENT_SCOPE)
-        endif()
-    elseif("${_c_list_type}" STREQUAL "map")
-        cpp_map_has_key("${_c_list}" _c_temp "${_c_item}")
-        set("${_c_result}" "${_c_temp}" PARENT_SCOPE)
-    elseif("${_c_list_type}" STREQUAL "desc")
+    set(_c_temp_result FALSE)
+
+    if("${_c_list_type}" STREQUAL "map")
+        cpp_map_has_key("${_c_list}" _c_temp_result "${_c_item}")
+    elseif("${_c_list_type}" STREQUAL "desc") #Substring matching
         string(FIND "${_c_list}" "${_c_item}" _c_pos)
         if(NOT "${_c_pos}" STREQUAL "-1")
-            set("${_c_result}" TRUE PARENT_SCOPE)
+            set(_c_temp_result TRUE)
         endif()
-    else()
-        cpp_raise(BAD_LIST_TYPE "List is of type ${_c_list_type}")
+    else() # Treat it like a single element list or a list
+        if("${_c_item}" IN_LIST _c_list)
+            set(_c_temp_result TRUE)
+        endif()
     endif()
+
+    set("${_c_result}" "${_c_temp_result}" PARENT_SCOPE)
 endfunction()

--- a/cmake/cmakepp_lang/algorithm/contains.cmake
+++ b/cmake/cmakepp_lang/algorithm/contains.cmake
@@ -55,13 +55,16 @@ include(cmakepp_lang/utilities/return)
 #    set(a_list "hello" "world")
 #    cpp_contains(result "hello" "${a_list}")
 #    message("The list contains 'hello': ${result}")  # Will print TRUE
-# 
+#
 # Error Checking
 # ==============
 #
 # If CMakePP is run in debug mode this function will ensure that it is called
 # with the correct number of arguments and that those arguments have the correct
 # types. These error checks are only performed if CMakePP is run in debug mode.
+#
+# :raises BAD_LIST_TYPE: If ``list`` is not recognized as a desc, list, or map.
+#
 #]]
 function(cpp_contains _c_result _c_item _c_list)
     cpp_assert_signature("${ARGV}" desc str str)
@@ -81,5 +84,7 @@ function(cpp_contains _c_result _c_item _c_list)
         if(NOT "${_c_pos}" STREQUAL "-1")
             set("${_c_result}" TRUE PARENT_SCOPE)
         endif()
+    else()
+        cpp_raise(BAD_LIST_TYPE "List is of type ${_c_list_type}")
     endif()
 endfunction()

--- a/tests/algorithm/contains.cmake
+++ b/tests/algorithm/contains.cmake
@@ -69,9 +69,13 @@ function("${CMAKETEST_TEST}")
         endfunction()
     endfunction()
 
-    ct_add_section(NAME [[bad_type]] EXPECTFAIL)
+    ct_add_section(NAME [[other_type]])
     function("${CMAKETEST_SECTION}")
         cpp_contains(result "world" TRUE)
+        ct_assert_false(result)
+
+        cpp_contains(result "TRUE" TRUE)
+        ct_assert_true(result)
     endfunction()
 
 endfunction()

--- a/tests/algorithm/contains.cmake
+++ b/tests/algorithm/contains.cmake
@@ -68,4 +68,10 @@ function("${CMAKETEST_TEST}")
             ct_assert_equal(result FALSE)
         endfunction()
     endfunction()
+
+    ct_add_section(NAME [[bad_type]] EXPECTFAIL)
+    function("${CMAKETEST_SECTION}")
+        cpp_contains(result "world" TRUE)
+    endfunction()
+
 endfunction()


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No

**Description**
`cpp_contains` dispatches on the type of container it is searching. Before this PR it failed silently if the container was recognized as a type other than `desc` (a single element list), `list`, or `map`. This PR now adds an "else" clause which triggers when the type is anything other than `map` or `desc` (notably `list` is addressed by the else clause). 

**TODOs**
Longer term the fact that there is an ambiguity between wanting `cpp_contains` to look for a substring and comparing against a single element list is perhaps looking for trouble. Bluntly, I suggest deprecating this function as it doesn't save that many keystrokes and it's likely to cause problems.
